### PR TITLE
analysis of Tier1 SDKs stateless vs stateful

### DIFF
--- a/proposals/SessionState/cross-sdk-stateless-vs-stateful-overview.md
+++ b/proposals/SessionState/cross-sdk-stateless-vs-stateful-overview.md
@@ -1,0 +1,238 @@
+# Cross-SDK Analysis: Stateless vs Stateful in MCP
+
+> Comparison of C#, Python, TypeScript, and Go MCP SDK implementations  
+> Goal: Identify commonalities and differences to inform a standard definition
+
+---
+
+## Executive Summary
+
+All four SDKs agree on the **fundamental concept**: stateless mode creates ephemeral, per-request sessions that cannot support server→client requests (sampling, elicitation, roots). However, they diverge significantly in **how they implement it**, **what they guard against**, and **how much the developer must do manually**.
+
+**Key finding**: There is strong consensus on *what* stateless means, but no consensus on *how* to implement it. A standard should codify the "what" while allowing flexibility in the "how."
+
+---
+
+## 1. Universal Agreements (Shared by All 4 SDKs)
+
+### ✅ Core Principle
+All SDKs agree: **stateless mode means no persistent session between HTTP requests**.
+
+| Shared Behavior | C# | Python | TypeScript | Go |
+|---|:---:|:---:|:---:|:---:|
+| Each request gets a fresh transport/session | ✅ | ✅ | ✅ | ✅ |
+| Streamable HTTP is the transport | ✅ | ✅ | ✅ | ✅ |
+| Session ID is absent or unused for routing | ✅ | ✅ | ✅ | ✅ |
+| No persistent SSE stream (GET) | ✅ | ✅ | ✅ | ✅ |
+| Tools work in stateless mode | ✅ | ✅ | ✅ | ✅ |
+| Prompts work in stateless mode | ✅ | ✅ | ✅ | ✅ |
+| Resources work in stateless mode | ✅ | ✅ | ✅ | ✅ |
+| Completions work in stateless mode | ✅ | ✅ | ✅ | ✅ |
+| Logging works (within request context) | ✅ | ✅ | ✅ | ✅ |
+| Progress notifications work (within request) | ✅ | ✅ | ✅ | ✅ |
+
+### ❌ Features Blocked in Stateless Mode
+All SDKs agree these features **require** stateful mode:
+
+| Blocked Feature | Reason |
+|---|---|
+| **Sampling** (server→client) | No persistent connection for client to respond |
+| **Elicitation** (server→client) | No persistent connection for client to respond |
+| **Roots listing** (server→client) | No persistent connection for client to respond |
+| **Unsolicited notifications** | No GET SSE stream to deliver them |
+| **SSE stream resumability** | No persistent session to resume |
+
+### 🔀 Initialization Handling
+All SDKs skip the normal `initialize`→`initialized` handshake in stateless mode by pre-populating session state:
+
+| SDK | Mechanism |
+|---|---|
+| C# | Sets `ClientCapabilities = null`; uses `KnownClientInfo` option |
+| Python | `InitializationState.Initialized` — starts as already initialized |
+| TypeScript | New server per request; no init handshake required |
+| Go | Peeks at request body; pre-sets `ServerSessionState` if no `initialize` message found |
+
+---
+
+## 2. Key Differences
+
+### 2.1 Configuration Model
+
+| SDK | Configuration | Explicit Flag? |
+|---|---|:---:|
+| **C#** | `HttpServerTransportOptions.Stateless = true` | ✅ Yes |
+| **Python** | `StreamableHTTPSessionManager(stateless=True)` | ✅ Yes |
+| **Go** | `StreamableHTTPOptions.Stateless = true` | ✅ Yes |
+| **TypeScript** | `sessionIdGenerator: undefined` + manual per-request lifecycle | ❌ No |
+
+**Gap**: TypeScript is the only SDK without an explicit `stateless` boolean. Stateless behavior is an emergent property of how the developer wires things up. This makes it harder to reason about and enforce.
+
+### 2.2 Session Manager
+
+| SDK | Built-in Session Manager | Stateless Lifecycle |
+|---|---|---|
+| **C#** | `StatefulSessionManager` (for stateful); custom handler for stateless | Automatic — framework creates/destroys per request |
+| **Python** | `StreamableHTTPSessionManager` handles both modes | Automatic — manager creates/destroys per request |
+| **Go** | `StreamableHTTPHandler` handles both modes | Automatic — handler defers `session.Close()` |
+| **TypeScript** | ❌ None built-in | **Manual** — developer must create/destroy server per request |
+
+**Gap**: TypeScript puts the entire session lifecycle burden on the developer. All other SDKs handle it automatically.
+
+### 2.3 Runtime Guards for Blocked Features
+
+| SDK | Guard Mechanism | Error Type |
+|---|---|---|
+| **C#** | `ClientCapabilities == null` check; throws `InvalidOperationException` | Framework exception |
+| **Python** | Explicit `self._stateless` flag; raises `StatelessModeNotSupported` | **Dedicated exception class** |
+| **Go** | Transport-level rejection; server→client requests fail immediately | Transport error |
+| **TypeScript** | ❌ **No explicit guards** | Transport closed → generic error |
+
+**Gap**: Only Python has a dedicated, named exception for stateless mode violations. C# uses an existing exception type. Go rejects at transport level. TypeScript has no guards at all — the failure is a generic transport error when the closed connection can't deliver the message.
+
+**Recommendation for standard**: SDKs SHOULD provide explicit runtime errors when stateless-incompatible features are attempted, with a clear error message indicating that the feature requires stateful mode.
+
+### 2.4 HTTP Route Handling
+
+| SDK | GET route in stateless | DELETE route in stateless |
+|---|---|---|
+| **C#** | **Unmapped entirely** (no route registered) | **Unmapped entirely** |
+| **Python** | Mapped but returns error/no-op | Mapped but returns error/no-op |
+| **Go** | Returns **405 Method Not Allowed** with `Allow: POST` header | Mapped but effectively no-op (session may be nil) |
+| **TypeScript** | **Developer manually returns 405** | **Developer manually returns 405** |
+
+**Gap**: No consistent behavior. C# is strictest (routes don't exist). Go follows HTTP spec (405 + Allow header). Python keeps routes but they fail. TypeScript delegates to the developer entirely.
+
+**Recommendation for standard**: Stateless servers SHOULD return 405 Method Not Allowed for GET and DELETE requests, with an `Allow: POST` response header (following RFC 9110 §15.5.6).
+
+### 2.5 Session ID in Stateless Mode
+
+| SDK | Session ID in Stateless |
+|---|---|
+| **C#** | Empty string (`""`) internally |
+| **Python** | `None` |
+| **Go** | **Optional — can have logical session IDs** for logging/tracing |
+| **TypeScript** | Not generated |
+
+**Gap**: Go uniquely allows session IDs in stateless mode for observability purposes. Other SDKs use absent/null/empty session IDs.
+
+**Recommendation for standard**: Stateless servers MUST NOT send the `Mcp-Session-Id` header in responses. Servers MAY use internal session identifiers for logging/tracing purposes, but these MUST NOT be exposed to clients.
+
+### 2.6 Change Notifications (ListChanged)
+
+| SDK | ListChanged notifications in stateless |
+|---|---|
+| **C#** | **Skipped** — notification handlers not registered |
+| **Python** | Not explicitly addressed |
+| **Go** | Debounced and sent, but unlikely to reach any client |
+| **TypeScript** | Server has no awareness of mode |
+
+**Gap**: Only C# explicitly skips registering ListChanged handlers in stateless mode. Go still sends them (wastefully). This should be standardized.
+
+### 2.7 Known Client Info (Pre-configuration)
+
+| SDK | Pre-configure client capabilities? |
+|---|---|
+| **C#** | ✅ `McpServerOptions.KnownClientInfo` |
+| **Python** | ❌ |
+| **Go** | Partial — `ProtocolVersion` from header |
+| **TypeScript** | ❌ |
+
+**Gap**: Only C# allows pre-configuring expected client capabilities for stateless mode. This is useful when a server knows its clients and wants to tailor responses.
+
+### 2.8 Performance Optimizations for Stateless
+
+| SDK | Stateless-specific optimization |
+|---|---|
+| **C#** | `ScopeRequests = false` (uses `HttpContext.RequestServices` directly) |
+| **Python** | None noted |
+| **Go** | `SchemaCache` — caches JSON schemas to avoid repeated reflection |
+| **TypeScript** | None noted |
+
+---
+
+## 3. Proposed Standard Definition
+
+Based on the cross-SDK analysis, here is a proposed standard:
+
+### 3.1 Stateless Mode MUST
+
+1. **Not maintain session state between HTTP requests** — each POST creates an independent processing context
+2. **Not send the `Mcp-Session-Id` response header** — clients MUST NOT expect session continuity
+3. **Support all read-only MCP operations**: tools (list, call), prompts (list, get), resources (list, read, templates), completions, ping
+4. **Support in-request notifications**: logging and progress notifications within the scope of a POST response
+5. **Reject server→client requests** with a clear error: sampling, elicitation, roots listing
+6. **Return 405 Method Not Allowed** for GET and DELETE HTTP methods (with `Allow: POST` header)
+
+### 3.2 Stateless Mode SHOULD
+
+1. **Provide explicit runtime errors** when stateless-incompatible features are attempted (not generic transport failures)
+2. **Skip the `initialize`/`initialized` handshake** — servers should accept requests without prior initialization
+3. **Accept `initialize` requests** if sent — for clients that don't know the server is stateless
+4. **Not register change notification handlers** — there's no one to notify
+5. **Support the `Mcp-Protocol-Version` header** for version negotiation without initialization
+
+### 3.3 Stateless Mode MAY
+
+1. Use internal session identifiers for logging/tracing (but not expose them to clients)
+2. Pre-configure expected client capabilities via server options
+3. Implement caching optimizations for repeated schema generation
+4. Support `initialize`/`initialized` for compatibility with clients that always send them
+
+### 3.4 Stateful Mode MUST
+
+1. **Generate and send `Mcp-Session-Id` header** after initialization
+2. **Validate `Mcp-Session-Id` on subsequent requests** — reject unknown session IDs
+3. **Support the full `initialize`→`initialized` handshake**
+4. **Support GET for SSE streaming** (standalone server→client channel)
+5. **Support DELETE for session termination**
+6. **Support all MCP features** including server→client requests (sampling, elicitation, roots)
+
+### 3.5 Stateful Mode SHOULD
+
+1. Implement session timeout/idle cleanup
+2. Support SSE stream resumability via event stores
+3. Send ListChanged notifications when tools/prompts/resources are modified
+4. Provide session migration support for graceful upgrades
+
+---
+
+## 4. Summary Matrix
+
+| Dimension | C# | Python | Go | TypeScript |
+|---|---|---|---|---|
+| **Explicit `stateless` flag** | ✅ | ✅ | ✅ | ❌ |
+| **Built-in session manager** | ✅ | ✅ | ✅ | ❌ |
+| **Auto per-request lifecycle** | ✅ | ✅ | ✅ | ❌ (manual) |
+| **Dedicated stateless exception** | ❌ (uses existing) | ✅ (`StatelessModeNotSupported`) | ❌ (transport-level) | ❌ (no guards) |
+| **GET → 405 in stateless** | ✅ (unmapped) | ⚠️ (partial) | ✅ | ⚠️ (manual) |
+| **DELETE → 405 in stateless** | ✅ (unmapped) | ⚠️ (partial) | ⚠️ (no-op) | ⚠️ (manual) |
+| **Skips init handshake** | ✅ | ✅ | ✅ | ✅ |
+| **Blocks sampling** | ✅ | ✅ | ✅ | ⚠️ (implicit) |
+| **Blocks elicitation** | ✅ | ✅ | ✅ | ⚠️ (implicit) |
+| **Blocks roots** | ✅ | ✅ | ✅ | ⚠️ (implicit) |
+| **Skips ListChanged** | ✅ | ❌ | ❌ | ❌ |
+| **Stateless perf optimization** | ✅ (scope) | ❌ | ✅ (cache) | ❌ |
+| **Pre-configure client info** | ✅ | ❌ | Partial | ❌ |
+| **Session ID in stateless** | `""` | `None` | Optional | Not generated |
+
+---
+
+## 5. Recommendations for Standard
+
+### High Priority (Strong consensus, should standardize immediately)
+1. ✅ **Stateless = no persistent session** — universal agreement
+2. ✅ **Server→client requests blocked** — universal agreement
+3. ✅ **Tools/prompts/resources/completions always work** — universal agreement
+4. ⚠️ **GET/DELETE return 405** — Go does this correctly; standardize it
+
+### Medium Priority (Partial consensus, needs discussion)
+5. ⚠️ **Explicit `stateless` configuration flag** — 3/4 SDKs have it; TypeScript should add one
+6. ⚠️ **Explicit runtime guards** — 3/4 SDKs have them; TypeScript should add guards
+7. ⚠️ **No `Mcp-Session-Id` in stateless responses** — Go's "optional for logging" approach needs resolution
+8. ⚠️ **Built-in session manager** — 3/4 SDKs have one; TypeScript should consider adding one
+
+### Lower Priority (SDK-specific innovations worth evaluating)
+9. 💡 **Dedicated exception type** (Python's `StatelessModeNotSupported`) — clear DX, worth standardizing
+10. 💡 **Known client info** (C#'s `KnownClientInfo`) — useful for pre-configured deployments
+11. 💡 **Schema caching** (Go's `SchemaCache`) — performance optimization for stateless
+12. 💡 **Skip ListChanged registration** (C# approach) — avoids waste in stateless mode

--- a/proposals/SessionState/csharp-sdk_stateless-vs-stateful.md
+++ b/proposals/SessionState/csharp-sdk_stateless-vs-stateful.md
@@ -1,0 +1,55 @@
+# MCP C# SDK: Stateless vs Stateful Mode
+## Configuration
+Set via `HttpServerTransportOptions.Stateless` (default: `false`):
+```csharp
+builder.Services.AddMcpServer()
+    .WithHttpTransport(options => options.Stateless = true);
+```
+## Core Difference
+| Aspect | Stateful (default) | Stateless |
+|---|---|---|
+| **Session ID** | `Mcp-Session-Id` header on every response; tracked in `StatefulSessionManager` | No session ID; empty string internally |
+| **Session lifetime** | Persists across requests; managed by idle timeout (default 2hr) | One session created **per HTTP request**, then discarded |
+| **Load balancing** | Requires session affinity (sticky sessions) | No affinity needed — any instance can serve any request |
+| **Service scope** | New DI scope per request (configurable) | Uses `HttpContext.RequestServices` directly — scoped services come from ASP.NET Core request scope |
+## HTTP Endpoints
+| Endpoint | Stateful | Stateless |
+|---|---|---|
+| `POST /` | ✅ All JSON-RPC messages | ✅ All JSON-RPC messages (each request is independent) |
+| `GET /` | ✅ Unsolicited server→client SSE stream | ❌ **Not mapped** (405) |
+| `DELETE /` | ✅ Session termination | ❌ **Not mapped** (405) |
+| `GET /sse` (legacy SSE) | ✅ Mapped | ❌ **Not mapped** (404) |
+| `POST /message` (legacy SSE) | ✅ Mapped | ❌ **Not mapped** (404) |
+## Feature Support
+| Feature | Stateful | Stateless |
+|---|---|---|
+| **Tools** (list, call) | ✅ | ✅ |
+| **Prompts** (list, get) | ✅ | ✅ |
+| **Resources** (list, read, templates) | ✅ | ✅ |
+| **Completions** | ✅ | ✅ |
+| **Logging** (server→client in response) | ✅ | ✅ |
+| **Progress notifications** (in response) | ✅ | ✅ |
+| **Sampling** (server→client request) | ✅ | ❌ `InvalidOperationException` |
+| **Elicitation** (server→client request) | ✅ | ❌ `InvalidOperationException` |
+| **Roots** (server→client request) | ✅ | ❌ `InvalidOperationException` |
+| **Tasks** (async task management) | ✅ | ❌ `InvalidOperationException` |
+| **Unsolicited notifications** (e.g. `tools/changed`) | ✅ Auto-registered on collection changes | ❌ Not registered; `SendNotificationAsync` throws |
+| **Client capabilities** | ✅ Populated from `initialize` | ❌ **Always `null`** — server cannot know client capabilities |
+| **Session migration** (`ISessionMigrationHandler`) | ✅ Cross-instance restore | ❌ N/A |
+| **SSE resumability** (`EventStreamStore` + `Last-Event-ID`) | ✅ | ❌ Rejected with 400 |
+| **Polling** (`EnablePollingAsync`) | ✅ | ❌ `InvalidOperationException` |
+## Why These Restrictions?
+All disabled features share one trait: they require **server→client communication outside the POST response**. In stateless mode, responses to server-initiated requests (sampling, elicitation, roots) might arrive at a different process. Unsolicited notifications have no open GET stream to write to. Since the server doesn't track sessions, it can't correlate follow-up messages.
+## Key Implementation Details
+- **`StreamableHttpServerTransport.Stateless`** — transport-level flag that guards `SendMessageAsync()`, `HandleGetRequestAsync()`, and `HandlePostRequestAsync()` for server→client requests
+- **`McpServerImpl` constructor** (line 102) — skips registering `ToolListChanged`/`PromptListChanged`/`ResourceListChanged` notification handlers when stateless
+- **`ClientCapabilities` = `null`** in stateless mode — the guard used by `ThrowIfSamplingUnsupported()`, `ThrowIfRootsUnsupported()`, `ThrowIfElicitationUnsupported()`, and `ThrowIfTasksUnsupported()`
+- **`McpServerOptions.KnownClientInfo`** — can pre-populate client info for stateless servers that encode knowledge in the session ID
+## When to Use Which
+| Use Case | Mode |
+|---|---|
+| Horizontally scaled API behind a load balancer | **Stateless** |
+| Single-instance or session-affinity deployment needing full MCP features | **Stateful** |
+| Server needs to request sampling/elicitation/roots from client | **Stateful** |
+| Server pushes unsolicited notifications (e.g., dynamic tool lists) | **Stateful** |
+| Simple tool-serving server (no server→client requests needed) | **Stateless** ✅ simplest

--- a/proposals/SessionState/go-sdk-stateless-vs-stateful.md
+++ b/proposals/SessionState/go-sdk-stateless-vs-stateful.md
@@ -1,0 +1,169 @@
+# Go MCP SDK: Stateless vs Stateful Mode
+
+> Analysis of [modelcontextprotocol/go-sdk](https://github.com/modelcontextprotocol/go-sdk) (`main` branch, March 2026)
+
+## Configuration
+
+```go
+handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+    return server
+}, &mcp.StreamableHTTPOptions{
+    Stateless: true,
+})
+```
+
+### Key parameters affected by mode
+
+| Parameter | Stateful | Stateless |
+|---|---|---|
+| `Stateless` | `false` (default) | `true` |
+| `SessionTimeout` | Optional idle timeout | Ignored (sessions are ephemeral) |
+| `EventStore` | Optional (enables resumability) | Usable but typically not set |
+| `JSONResponse` | Optional | Optional |
+| `GetSessionID` (on `ServerOptions`) | Generates unique IDs | May return empty string (no header) |
+
+## Core Difference
+
+| Aspect | Stateful (default) | Stateless |
+|---|---|---|
+| **Session tracking** | `Mcp-Session-Id` header; sessions stored in `StreamableHTTPHandler.sessions` map | Sessions created per request and closed via `defer session.Close()` |
+| **Session lifetime** | Persists across requests; optional `SessionTimeout` for idle cleanup | Ephemeral — created, used, and closed within a single HTTP request |
+| **Initialization** | Normal `initialize`→`initialized` handshake | Pre-initialized with default `ServerSessionState` (skips handshake if not in body) |
+| **Load balancing** | Requires session affinity | No affinity needed |
+| **Server→client requests** | ✅ Supported | ❌ Rejected — "no way for the client to respond" |
+
+## HTTP Endpoints
+
+| Endpoint | Stateful | Stateless |
+|---|---|---|
+| `POST /` | ✅ All JSON-RPC messages | ✅ All JSON-RPC messages (ephemeral session) |
+| `GET /` | ✅ Standalone SSE stream for server→client messages | ❌ **405 Method Not Allowed** (with `Allow: POST` header) |
+| `DELETE /` | ✅ Session termination (closes session, returns 204) | ⚠️ Mapped but no-ops (session may be nil in stateless) |
+
+## Feature Support
+
+| Feature | Stateful | Stateless |
+|---|---|---|
+| **Tools** (list, call) | ✅ | ✅ |
+| **Prompts** (list, get) | ✅ | ✅ |
+| **Resources** (list, read, templates, subscribe) | ✅ | ✅ |
+| **Completions** | ✅ | ✅ |
+| **Logging** (server→client notifications in request context) | ✅ | ✅ (within POST response) |
+| **Progress notifications** | ✅ | ✅ (within POST response) |
+| **Sampling** (server→client request) | ✅ | ❌ Rejected at transport level |
+| **Elicitation** (server→client request) | ✅ | ❌ Rejected at transport level |
+| **Roots** (server→client request) | ✅ | ❌ Rejected at transport level |
+| **Unsolicited notifications** | ✅ Via GET SSE stream or request context | ⚠️ Only within POST request context (no GET stream) |
+| **SSE resumability** (`EventStore`) | ✅ When configured | Technically possible but no persistent session to resume |
+| **Session timeout** | ✅ Via `SessionTimeout` option | N/A (sessions are ephemeral) |
+| **Change notifications** (tools/prompts/resources changed) | ✅ Sent to all sessions | ⚠️ Sessions are ephemeral; notifications may not reach anyone |
+
+## Key Implementation Details
+
+### StreamableHTTPHandler — The Central Controller
+
+**File:** `mcp/streamable.go`
+
+The `StreamableHTTPHandler` is an `http.Handler` that serves as the session manager (unlike TypeScript which has no built-in manager). Key behavior:
+
+```go
+func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+    // ... security checks (DNS rebinding, CORS, Content-Type) ...
+
+    // GET in stateless mode → 405
+    if req.Method == http.MethodGet && h.opts.Stateless {
+        w.Header().Set("Allow", "POST")
+        http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    // Session lookup
+    sessionID := req.Header.Get("Mcp-Session-Id")
+    sessInfo := h.sessions[sessionID]
+    if sessInfo == nil && !h.opts.Stateless {
+        http.Error(w, "session not found", http.StatusNotFound)
+        return
+    }
+    // ... create new session if needed ...
+}
+```
+
+### Stateless Session Pre-initialization
+
+When creating a stateless session, the Go SDK peeks at the request body to check for `initialize`/`initialized` messages. If not present, it creates a pre-initialized `ServerSessionState`:
+
+```go
+if stateless {
+    state := new(ServerSessionState)
+    if !hasInitialize {
+        state.InitializeParams = &InitializeParams{
+            ProtocolVersion: protocolVersion,
+        }
+    }
+    if !hasInitialized {
+        state.InitializedParams = new(InitializedParams)
+    }
+    state.LogLevel = "info"
+    connectOpts = &ServerSessionOptions{State: state}
+}
+```
+
+This means stateless sessions **can** still process normal `initialize` requests — they're just not required.
+
+### Server→Client Request Blocking
+
+The `StreamableServerTransport` has a `Stateless` field. When set to `true`, server→client requests (sampling, elicitation, roots) are rejected because the transport knows there's no way for the client to respond:
+
+> "A stateless server does not validate the Mcp-Session-Id header, and uses a temporary session with default initialization parameters. Any server→client request is rejected immediately as there's no way for the client to respond."
+
+### Session ID and Stateless Interaction
+
+Uniquely among the SDKs, the Go SDK notes that stateless servers **may still have logical session IDs**:
+
+```go
+// From the distributed example:
+// Distributed MCP servers must be stateless, because there's no guarantee
+// that subsequent requests for a session land on the same backend. However,
+// they may still have logical session IDs, as can be seen with verbose logging.
+```
+
+The session ID in stateless mode is generated but not used for session routing — it's purely for logging/tracing purposes.
+
+### SchemaCache for Stateless Performance
+
+The Go SDK includes a `SchemaCache` option specifically designed for stateless deployments:
+
+```go
+// SchemaCache, if non-nil, caches JSON schemas to avoid repeated
+// reflection. This is useful for stateless server deployments where
+// a new [Server] is created for each request.
+SchemaCache *SchemaCache
+```
+
+This is unique to the Go SDK — other SDKs don't have this optimization.
+
+### Change Notification Debouncing
+
+The Go SDK debounces change notifications (tools/prompts/resources list changed) with a 10ms delay. In stateless mode, these notifications are still sent but may not reach any client since sessions are ephemeral.
+
+## Comparison with Other SDKs
+
+| Aspect | Go | C# | Python | TypeScript |
+|---|---|---|---|---|
+| **Config flag** | `StreamableHTTPOptions.Stateless` | `HttpServerTransportOptions.Stateless` | `StreamableHTTPSessionManager(stateless=...)` | `sessionIdGenerator: undefined` |
+| **Session manager** | `StreamableHTTPHandler` | `StatefulSessionManager` | `StreamableHTTPSessionManager` | ❌ Manual |
+| **GET route in stateless** | 405 Method Not Allowed | 405 (unmapped) | Mapped but no persistent stream | 405 (manual) |
+| **Init skip** | Peeks body; pre-initializes if needed | Pre-initialized | `InitializationState.Initialized` | N/A |
+| **Schema caching** | ✅ `SchemaCache` for stateless perf | ❌ | ❌ | ❌ |
+| **Session IDs in stateless** | Optional (for logging) | Empty string | `None` | Not generated |
+| **Idle timeout** | `SessionTimeout` option | `IdleTimeout` (2hr default) | `session_idle_timeout` | Manual |
+
+## When to Use Which
+
+| Use Case | Mode |
+|---|---|
+| Distributed servers behind a load balancer | **Stateless** (`Stateless: true`) |
+| Single-instance or session-affinity deployment | **Stateful** (default) |
+| Server needs sampling/elicitation/roots | **Stateful** |
+| High-throughput stateless with schema reflection | **Stateless** + `SchemaCache` |
+| Simple tool server, no server→client requests | **Stateless** ✅ simplest |

--- a/proposals/SessionState/python-sdk-stateless-vs-stateful.md
+++ b/proposals/SessionState/python-sdk-stateless-vs-stateful.md
@@ -1,0 +1,186 @@
+# Python MCP SDK: Stateless vs Stateful Mode
+
+> Analysis of [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk) (`main` branch, March 2026)
+
+## Configuration
+
+### Via StreamableHTTPSessionManager (low-level)
+
+```python
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+session_manager = StreamableHTTPSessionManager(
+    app=server,
+    stateless=True,  # default: False
+)
+```
+
+### Via FastMCP (high-level)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+mcp.run(transport="streamable-http")  # stateless configured via session manager
+```
+
+### Key parameters affected by mode
+
+| Parameter | Stateful | Stateless |
+|---|---|---|
+| `stateless` | `False` (default) | `True` |
+| `mcp_session_id` | UUID hex string per session | `None` — no session ID |
+| `event_store` | Optional (enables resumability) | Forced to `None` |
+| `session_idle_timeout` | Optional (e.g. 1800s) | **RuntimeError** if set |
+| `retry_interval` | Optional (SSE polling) | Ignored (no event store) |
+
+## Core Difference
+
+| Aspect | Stateful (default) | Stateless |
+|---|---|---|
+| **Session tracking** | `Mcp-Session-Id` header; sessions stored in `_server_instances` dict | No session ID; fresh transport per request |
+| **Session lifetime** | Persists across requests until idle timeout, DELETE, or shutdown | Transport created → request handled → `terminate()` called |
+| **Initialization state** | Starts as `NotInitialized`, progresses through handshake | Starts as `Initialized` (skips init handshake) |
+| **Load balancing** | Requires session affinity (sticky sessions) | No affinity needed — any instance can serve any request |
+| **Service scope** | Single `Server.run()` loop per session; shared state | New `Server.run()` per request; no shared state |
+
+## HTTP Endpoints
+
+| Endpoint | Stateful | Stateless |
+|---|---|---|
+| `POST /` | ✅ All JSON-RPC messages; session correlated via `Mcp-Session-Id` | ✅ All JSON-RPC messages (each request independent) |
+| `GET /` | ✅ Standalone SSE stream for unsolicited server→client messages | ✅ Mapped but **no persistent stream** (transport terminates after request) |
+| `DELETE /` | ✅ Explicit session termination | Returns **405 Method Not Allowed** (`mcp_session_id` is `None`) |
+
+> **Note:** Unlike the C# SDK which unmaps GET/DELETE routes entirely in stateless mode, the Python SDK keeps them mapped but they effectively no-op or error since there's no session to interact with.
+
+## Feature Support
+
+| Feature | Stateful | Stateless |
+|---|---|---|
+| **Tools** (list, call) | ✅ | ✅ |
+| **Prompts** (list, get) | ✅ | ✅ |
+| **Resources** (list, read, templates, subscribe) | ✅ | ✅ |
+| **Completions** | ✅ | ✅ |
+| **Logging** (server→client notifications) | ✅ | ✅ |
+| **Progress notifications** | ✅ | ✅ |
+| **Ping** | ✅ | ✅ |
+| **Sampling** (`create_message`) | ✅ | ❌ `StatelessModeNotSupported` |
+| **Elicitation** (`elicit_form` / `elicit_url`) | ✅ | ❌ `StatelessModeNotSupported` |
+| **Roots** (`list_roots`) | ✅ | ❌ `StatelessModeNotSupported` |
+| **Unsolicited notifications** (e.g. `tools/list_changed`) | ✅ Via GET SSE stream | ⚠️ No persistent stream; effectively dropped |
+| **SSE resumability** (`EventStore` + `Last-Event-ID`) | ✅ When `event_store` provided | ❌ No event store in stateless mode |
+| **Session idle timeout** | ✅ Via `session_idle_timeout` param | ❌ `RuntimeError` if configured |
+| **Tasks** (experimental) | ✅ | ⚠️ Depends on implementation; session-level checks may block |
+| **JSON response mode** (`is_json_response_enabled`) | ✅ | ✅ |
+
+## Why These Restrictions?
+
+The `StatelessModeNotSupported` exception docstring explains it clearly:
+
+> *"Server-to-client requests (sampling, elicitation, list_roots) are not supported in stateless HTTP mode because there is no persistent connection for bidirectional communication."*
+
+In stateless mode, each request creates a fresh transport that's terminated immediately after handling. There's no long-lived session to route server→client requests back through. Any response to a server-initiated request might arrive at a completely different process.
+
+## Key Implementation Details
+
+### StatelessModeNotSupported Exception
+**File:** `src/mcp/shared/exceptions.py`
+
+```python
+class StatelessModeNotSupported(RuntimeError):
+    def __init__(self, method: str):
+        super().__init__(
+            f"Cannot use {method} in stateless HTTP mode. "
+            "Stateless mode does not support server-to-client requests. "
+            "Use stateful mode (stateless_http=False) to enable this feature."
+        )
+```
+
+Unlike the C# SDK (which uses `InvalidOperationException` and guards via `ClientCapabilities == null`), the Python SDK has a **dedicated exception type** for this error.
+
+### Session Manager Dispatch
+**File:** `src/mcp/server/streamable_http_manager.py`
+
+```python
+async def handle_request(self, scope, receive, send):
+    if self.stateless:
+        await self._handle_stateless_request(scope, receive, send)
+    else:
+        await self._handle_stateful_request(scope, receive, send)
+```
+
+**Stateless path:**
+1. Creates `StreamableHTTPServerTransport(mcp_session_id=None, event_store=None)`
+2. Starts `Server.run(..., stateless=True)` in a new task
+3. Handles the HTTP request
+4. Calls `transport.terminate()` immediately after
+
+**Stateful path:**
+1. Checks `Mcp-Session-Id` header
+2. If existing session → routes to its transport
+3. If new → creates transport with UUID session ID, stores in `_server_instances`
+4. Manages idle timeout via `anyio.CancelScope`
+
+### ServerSession Initialization Skip
+**File:** `src/mcp/server/session.py`
+
+```python
+def __init__(self, ..., stateless: bool = False):
+    self._stateless = stateless
+    self._initialization_state = (
+        InitializationState.Initialized if stateless
+        else InitializationState.NotInitialized
+    )
+```
+
+In stateless mode, the session starts pre-initialized — the client still sends an `initialize` request but the server doesn't enforce the handshake ordering.
+
+### Guards in ServerSession Methods
+
+Each server→client request method checks `self._stateless`:
+
+```python
+async def create_message(self, ...):   # sampling
+    if self._stateless:
+        raise StatelessModeNotSupported(method="sampling")
+
+async def list_roots(self):
+    if self._stateless:
+        raise StatelessModeNotSupported(method="list_roots")
+
+async def elicit_form(self, ...):
+    if self._stateless:
+        raise StatelessModeNotSupported(method="elicitation")
+
+async def elicit_url(self, ...):
+    if self._stateless:
+        raise StatelessModeNotSupported(method="elicitation")
+```
+
+## Comparison with C# SDK
+
+| Aspect | C# SDK | Python SDK |
+|---|---|---|
+| **Config property** | `HttpServerTransportOptions.Stateless` | `StreamableHTTPSessionManager(stateless=...)` |
+| **Session ID** | Empty string internally | `None` |
+| **Error type** | `InvalidOperationException` | `StatelessModeNotSupported` (dedicated) |
+| **Guard mechanism** | `ClientCapabilities == null` check | Explicit `self._stateless` flag |
+| **GET/DELETE routes** | Unmapped entirely (405) | Mapped but effectively no-op/error |
+| **SSE legacy endpoints** | `/sse` and `/message` disabled | N/A (Python SDK doesn't have legacy SSE in stateless) |
+| **Change notifications** | Notification handlers not registered | No special handling; dropped silently if no GET stream |
+| **Idle timeout** | Unused in stateless | `RuntimeError` if configured with stateless |
+| **Session migration** | `ISessionMigrationHandler` (stateful only) | Not implemented |
+| **Web framework** | ASP.NET Core | Starlette/ASGI |
+| **Blocked features** | Sampling, elicitation, roots, tasks, unsolicited notifications | Sampling, elicitation, roots (same core set) |
+
+## When to Use Which
+
+| Use Case | Mode |
+|---|---|
+| Horizontally scaled API behind a load balancer | **Stateless** |
+| Single-instance or session-affinity deployment needing full MCP features | **Stateful** |
+| Server needs sampling, elicitation, or roots from client | **Stateful** |
+| Server pushes unsolicited notifications (e.g., dynamic tool lists) | **Stateful** |
+| Simple tool-serving server (no server→client requests needed) | **Stateless** ✅ simplest |
+| Need SSE resumability for unreliable connections | **Stateful** + `EventStore` |

--- a/proposals/SessionState/typescript-sdk-stateless-vs-stateful.md
+++ b/proposals/SessionState/typescript-sdk-stateless-vs-stateful.md
@@ -1,0 +1,130 @@
+# TypeScript MCP SDK: Stateless vs Stateful Mode
+
+> Analysis of [modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) (`main` branch, March 2026)
+
+## Configuration
+
+### Stateless mode — Manual transport wiring
+
+The TypeScript SDK does **not** have a built-in `stateless` boolean flag. Instead, stateless behavior is achieved by setting `sessionIdGenerator: undefined` on `NodeStreamableHTTPServerTransport` and creating a **new server + transport per request**:
+
+```typescript
+// From examples/server/src/simpleStatelessStreamableHttp.ts
+app.post('/mcp', async (req, res) => {
+    const server = getServer();  // new server per request
+    const transport = new NodeStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined  // no session ID = stateless
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+    res.on('close', () => {
+        transport.close();
+        server.close();
+    });
+});
+```
+
+### Stateful mode — Session manager handles routing
+
+```typescript
+const transport = new NodeStreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),  // generates session IDs
+    eventStore: new InMemoryEventStore(),     // optional resumability
+});
+```
+
+### Key architectural difference
+
+Unlike C#, Python, and Go — which have a `stateless: boolean` property on a session manager or transport options — the TypeScript SDK uses **the absence of `sessionIdGenerator`** to signal stateless mode. The developer is responsible for wiring up the per-request lifecycle manually.
+
+## Core Difference
+
+| Aspect | Stateful | Stateless |
+|---|---|---|
+| **Session tracking** | `Mcp-Session-Id` header; session map maintained | No session ID; `sessionIdGenerator: undefined` |
+| **Session lifetime** | Persists across requests; managed by developer code | New server + transport per HTTP request; closed after response |
+| **Wiring** | Built-in session map in transport | **Manual**: developer creates/destroys server per request |
+| **Load balancing** | Requires session affinity | No affinity needed |
+
+## HTTP Endpoints
+
+| Endpoint | Stateful | Stateless |
+|---|---|---|
+| `POST /mcp` | ✅ All JSON-RPC messages | ✅ All JSON-RPC messages (fresh server each time) |
+| `GET /mcp` | ✅ Standalone SSE stream | ❌ **Developer returns 405** manually |
+| `DELETE /mcp` | ✅ Session termination | ❌ **Developer returns 405** manually |
+
+> **Key difference**: The TypeScript SDK does NOT automatically disable GET/DELETE routes. The stateless example manually returns 405 for these methods. This is left entirely to the application developer.
+
+## Feature Support
+
+| Feature | Stateful | Stateless |
+|---|---|---|
+| **Tools** (list, call) | ✅ | ✅ |
+| **Prompts** (list, get) | ✅ | ✅ |
+| **Resources** (list, read, templates) | ✅ | ✅ |
+| **Completions** | ✅ | ✅ |
+| **Logging** (via `ctx.mcpReq.log()`) | ✅ | ✅ (within request context) |
+| **Progress notifications** | ✅ | ✅ (within request context) |
+| **Sampling** (server→client request) | ✅ | ⚠️ **No explicit guard** — would fail at transport level |
+| **Elicitation** (server→client request) | ✅ | ⚠️ **No explicit guard** — would fail at transport level |
+| **Roots** (server→client request) | ✅ | ⚠️ **No explicit guard** — would fail at transport level |
+| **Unsolicited notifications** | ✅ Via GET SSE stream | ❌ No GET stream available |
+| **SSE resumability** (`EventStore`) | ✅ When event store provided | ❌ No event store in stateless pattern |
+| **Session timeout** | Developer-managed | N/A (transport closed per request) |
+
+## Why No Explicit Guards?
+
+Unlike C# (`InvalidOperationException`) and Python (`StatelessModeNotSupported`), the TypeScript SDK has **no runtime guards** that throw when attempting sampling/elicitation/roots in stateless mode. Instead:
+
+1. The transport is closed after each request, so there's no persistent connection for server→client requests
+2. Any attempt to send a server→client request would fail because the transport is already closed
+3. The failure mode is a transport error rather than a clear "stateless mode not supported" error
+
+This is a **significant difference** from other SDKs — the TypeScript SDK relies on the developer understanding what won't work, rather than enforcing it.
+
+## Key Implementation Details
+
+### `NodeStreamableHTTPServerTransport`
+
+The transport class is the core building block. Key configuration:
+
+- **`sessionIdGenerator`**: Function returning a session ID string, or `undefined` for stateless
+- **`eventStore`**: Optional `EventStore` for SSE resumability
+- **`onsessioninitialized`**: Callback after initialization handshake
+
+When `sessionIdGenerator` is `undefined`:
+- No `Mcp-Session-Id` header is sent in responses
+- The transport doesn't validate session IDs on incoming requests
+- No session state is maintained between requests
+
+### No Session Manager
+
+Unlike C# (`StatefulSessionManager`), Python (`StreamableHTTPSessionManager`), and Go (`StreamableHTTPHandler`), the TypeScript SDK **does not have a built-in session manager**. Session lifecycle is managed by the application code:
+
+- In stateful mode: the developer typically maintains a `Map<string, ServerSession>` 
+- In stateless mode: the developer creates and destroys everything per request
+
+### McpServer class
+
+The `McpServer` class has no awareness of stateless vs stateful mode. It's a pure protocol handler. The distinction is entirely at the transport layer.
+
+## Comparison with Other SDKs
+
+| Aspect | TypeScript | C# | Python | Go |
+|---|---|---|---|---|
+| **Stateless flag** | `sessionIdGenerator: undefined` | `Stateless = true` | `stateless=True` | `Stateless: true` |
+| **Explicit property** | ❌ No boolean flag | ✅ | ✅ | ✅ |
+| **Session manager** | ❌ Manual | ✅ `StatefulSessionManager` | ✅ `StreamableHTTPSessionManager` | ✅ `StreamableHTTPHandler` |
+| **Runtime guards** | ❌ None | ✅ `InvalidOperationException` | ✅ `StatelessModeNotSupported` | ✅ Rejected at transport |
+| **GET/DELETE disabling** | ❌ Manual 405s | ✅ Routes unmapped | ✅ Effectively no-ops | ✅ Returns 405 |
+| **Per-request lifecycle** | ✅ Manual | ✅ Automatic | ✅ Automatic | ✅ Automatic |
+
+## When to Use Which
+
+| Use Case | Mode |
+|---|---|
+| Horizontally scaled, no session affinity | **Stateless** (set `sessionIdGenerator: undefined`, new server per request) |
+| Full MCP features with persistent sessions | **Stateful** (set `sessionIdGenerator`, manage session map) |
+| Server needs sampling/elicitation/roots | **Stateful** |
+| Simple tool server behind a load balancer | **Stateless** ✅ simplest |


### PR DESCRIPTION
Explorations of  Stateless vs Stateful in SDKs today.  

Includes Typescript, Python, C#, Go
