### PR TITLE
Proposal: Pluggable Transport Interface for MCP SDKs

### DIFF
--- a/docs/pluggable/pluggable-transports-interface-research.md
+++ b/docs/pluggable/pluggable-transports-interface-research.md
@@ -1,0 +1,1023 @@
+# Pluggable MCP Transports Across the Official SDKs
+
+## Executive assessment
+
+**Yes. A narrower “pluggable transport” step—keeping MCP messages as JSON-RPC while making the transport/binding replaceable—is both feasible and, after the July 28, 2026 MCP specification, much better aligned with the protocol than SEP-2598 was when it was proposed.** The current specification now explicitly defines a transport as a **binding** that determines framing, delivery, metadata carriage, cancellation, and termination while leaving MCP message semantics unchanged. It explicitly permits custom transports, but requires them to preserve the JSON-RPC message format, MCP message patterns, and the per-request metadata model.
+
+That distinction is the key architectural answer to this research:
+
+> **MCP core semantics → JSON-RPC message model → pluggable binding/transport → actual communication substrate**
+
+`stdio` and Streamable HTTP are simply the two standardized bindings today. A WebSocket, `MessagePort`/`postMessage`, TCP socket, Unix socket, RPC framework, or another communication substrate can occupy the layer beneath the JSON-RPC message model without redefining MCP itself. The specification now says almost exactly this: custom transports may use any channel supporting bidirectional message exchange, while reliable bidirectional byte streams should normally reuse stdio's newline-delimited JSON-RPC framing.
+
+The SDK review produces an unusually strong result: **most of the ten official SDKs already have either an explicit transport interface/protocol or a public transport-injection seam.** Go, Java, C#, PHP, Rust, and Swift expose particularly clear abstractions; Kotlin already ships a WebSocket transport and an in-memory `ChannelTransport`; Python v2 accepts a custom `Transport` directly; TypeScript has public transport injection and a sophisticated internal transport split; Ruby has a client-side custom-transport contract but is less cleanly abstracted on the server side.
+
+My resulting feasibility assessment is:
+
+| SDK | Existing pluggability | Work to establish a stable transport SPI | Assessment |
+|---|---|---:|---|
+| TypeScript | Public `connect(transport)`; stdio/HTTP/in-memory; modern HTTP internally uses a per-request transport | Clarify/stabilize the v2 SPI and reconcile connection-oriented vs per-exchange APIs | **Low–Medium** |
+| Python | `Client` explicitly accepts a custom `Transport`; transport produces streams consumed by `JSONRPCDispatcher` | Client essentially done; server-side binding SPI should converge with modern dispatcher model | **Low–Medium** |
+| Java | Public `McpClientTransport`, `McpServerTransportProvider`, `McpTransport`; migration docs explicitly address custom implementors | Mostly documentation/conformance/common semantics | **Low** |
+| Kotlin | Multiple interchangeable transports; WebSocket already exists; `ChannelTransport` provides full duplex | Formalize extension contract rather than invent it | **Low** |
+| C# | Public `IClientTransport`; factory was deliberately changed toward direct transport injection; stream transports exist | Make client/server SPI semantics consistently documented | **Low** |
+| Go | Explicit `mcp.Transport`; `jsonrpc` package is specifically intended for custom-transport implementors | Mostly contract/conformance work | **Very low** |
+| PHP | Documentation explicitly says all transports implement `TransportInterface`; server accepts transport via `run()` | Align interface semantics with 2026 stateless binding model | **Low** |
+| Ruby | Client docs explicitly permit a user-defined transport with `send_request`; server transports remain more coupled to server/Rack behavior | Introduce a symmetric server-side exchange/binding interface | **Medium** |
+| Rust | README explicitly says any `Transport` implementation can be passed to `.serve(..)` | Primarily portability/conformance details | **Very low** |
+| Swift | Public `Transport` protocol and documented custom implementation; custom `NetworkTransport` precedent | Mostly common behavioral contract/conformance | **Very low** |
+
+So I would **not** frame this as “refactor ten SDKs to invent a Transport interface.” That overstates the work. A more accurate project is:
+
+**standardize what an MCP SDK transport extension point means, adjust the few SDKs whose public surfaces do not yet cleanly express those semantics, and build a cross-SDK conformance contract for third-party bindings.**
+
+That is a materially smaller and more achievable first step.
+
+## Protocol reality after the 2026 revision
+
+The most important fact for revisiting SEP-2598 is that MCP itself changed substantially after the SEP's April 2026 review.
+
+The July 28, 2026 specification defines a transport as a binding and says protocol semantics are identical across bindings. The binding determines framing and delivery, request-metadata carriage, cancellation, and termination. MCP messages themselves remain UTF-8 JSON-RPC. Standard bindings are stdio and Streamable HTTP; additional custom transports are explicitly permitted.
+
+The current requirements are particularly clear:
+
+* JSON-RPC messages **must** be UTF-8 encoded.
+* A binding must carry client requests/notifications to the server and server responses/notifications back to the client.
+* All protocol metadata is now principally in the JSON-RPC body.
+* A custom transport must preserve JSON-RPC, MCP message patterns, and the per-request metadata model.
+* A custom transport should document connection establishment, framing, and cancellation.
+* Reliable bidirectional byte-stream transports should normally reuse the newline-delimited stdio framing.
+
+This means **the protocol specification already has the conceptual “pluggable transport” layer**. What is missing is a sufficiently uniform SDK-level SPI through which application and library authors can implement that binding without forking an SDK.
+
+### Why the new stateless protocol makes this much easier
+
+The 2026 specification also removed one of the major complications that existed when SEP-2598 was reviewed: protocol-level sessions.
+
+MCP is now formally stateless. Servers must not infer protocol version, capabilities, client identity, conversation identity, or other protocol context from a connection. Every request carries the required metadata. Long-lived `subscriptions/listen` remains a request/response operation whose response happens to remain open; its state belongs to the request, not the underlying connection.
+
+The July 28 changelog makes the magnitude of this change explicit: protocol sessions and `Mcp-Session-Id` were removed; the `initialize`/`notifications/initialized` handshake was removed for the modern protocol; protocol version and client capabilities now accompany every request; standalone HTTP GET subscriptions were replaced by `subscriptions/listen`; and the protocol moved away from server-initiated JSON-RPC requests toward Multi Round-Trip Requests.
+
+This makes a binding abstraction dramatically cleaner.
+
+A connection no longer needs to mean:
+
+```text
+MCP protocol session
+    + negotiated identity
+    + capabilities
+    + conversation state
+    + request correlation
+    + transport lifecycle
+```
+
+Instead, it can mean only:
+
+```text
+resource used to carry independent MCP exchanges
+```
+
+That is precisely what you want for WebSocket connection pooling, worker/message-port connections, HTTP/2 multiplexing, gRPC channels, local sockets, or RPC-framework-managed channels. The same connection can carry unrelated requests because MCP explicitly forbids treating connection identity as protocol state.
+
+### SEP-2598 should be narrowed rather than resurrected unchanged
+
+SEP-2598 proposed two things together:
+
+1. a public `Transport` interface plus conformance harness in SDK core; and
+2. relaxation of the JSON-RPC wire-format requirement so custom transports could transcode MCP into Protobuf, CBOR, or other native representations.
+
+Those are separable ideas, and the second one generated much of the design resistance.
+
+Review discussion raised questions such as whether a native gRPC implementation should need a JSON-RPC request ID at all, whether all transports should support all MCP notifications, whether `initialize` should exist in a stateless transport, and whether response correlation should be exposed through request IDs in a general transport API.
+
+Another objection concerned process rather than architecture: requiring every Tier-1 SDK to expose an interface **and** maintain its own reusable conformance harness would impose substantial cross-SDK maintenance and tier-review burden. Reviewers suggested treating transport support more like an optional extension and putting transport-specific tests in the common conformance ecosystem instead. The SEP also still lacked its required prototype implementation.
+
+Those objections point toward a much better first SEP:
+
+> **Do not change MCP's JSON-RPC representation. Standardize the SDK extension seam for custom bindings that carry existing MCP JSON-RPC.**
+
+That eliminates most of the semantic translation problem.
+
+There is an additional reason not to revive the transcoding part of SEP-2598 unchanged: **the final July 28, 2026 specification now normatively says custom transports must preserve the JSON-RPC message format.**
+
+So today there are really two proposals:
+
+```text
+A. Pluggable binding carrying MCP JSON-RPC
+   → already compatible with the current specification
+   → appropriate first step
+
+B. Alternate MCP encodings / native RPC mappings
+   → changes the current normative protocol
+   → requires a separate future SEP
+```
+
+My recommendation is emphatically **A first, B later if still desirable**.
+
+## Cross-SDK transport architecture
+
+DeepWiki is useful for quickly locating the relevant architectural areas, but for this assessment the important conclusions were checked against the current official specification and repositories. The striking pattern is that the SDKs have independently converged on roughly the architecture you are proposing.
+
+### TypeScript
+
+The TypeScript SDK already makes transport selection explicit at the protocol boundary. A client creates a `Client`, constructs a transport such as `StreamableHTTPClientTransport`, `StdioClientTransport`, or an in-memory transport, and calls `client.connect(transport)`. The documentation explicitly says that downstream client behavior is independent of which transport branch was selected.
+
+Server code also has transport injection on the older/connection-oriented path: `McpServer.connect(transport)` is used with web-standard and Node Streamable HTTP transport implementations.
+
+The interesting complication is v2's modern 2026 HTTP serving path. `createMcpHandler()` classifies each HTTP request and creates a **single-exchange per-request transport** for modern requests. That is architecturally significant: it acknowledges that a current MCP transport is not necessarily a long-lived `start()/send()/onmessage()/close()` connection object.
+
+So TypeScript is not far from pluggability, but it is also evidence that **standardizing the old v1 transport lifecycle verbatim would be a mistake**. The SPI needs to encompass both:
+
+```text
+long-lived channel
+    stdio
+    WebSocket
+    MessagePort
+
+request-scoped exchange
+    Streamable HTTP
+    unary + streaming RPC
+    serverless handler
+```
+
+The TypeScript SDK's own design guidance says transport lifecycle belongs in the SDK but also requires concrete justification before adding public abstractions, so a transport proposal would be strongest if accompanied by an actual third-party binding such as `MessagePortTransport`.
+
+**Assessment: Low–Medium.** The seam exists; what is needed is to declare the correct v2-compatible third-party SPI rather than simply exporting the historical interface unchanged.
+
+### Python
+
+Python v2 is even more explicit. The high-level `Client` accepts a URL, subprocess, in-memory server, **or custom `Transport` instance**.
+
+More importantly, the implementation makes the separation visible. A custom `Transport` is entered as an asynchronous context manager and produces read/write streams; those streams are handed to `JSONRPCDispatcher`. In other words:
+
+```text
+custom Transport
+       ↓
+read/write message streams
+       ↓
+JSONRPCDispatcher
+       ↓
+MCP session/client behavior
+```
+
+The transport is therefore already separated from JSON-RPC dispatch.
+
+Python also has an in-process modern path that bypasses serialization and connects dispatchers directly, which is another useful architectural clue: **JSON-RPC serialization belongs at the remote-binding boundary, not inside MCP business logic.**
+
+The remaining issue is symmetry. The client custom-transport contract is clear; a fully general server-side third-party binding should have an equally direct way to deliver an independent incoming exchange to the modern server dispatcher without having to imitate Streamable HTTP or a legacy session loop.
+
+**Assessment: Low–Medium**, with most work on a clean server-facing binding API rather than on the client.
+
+### Java
+
+Java is essentially already there.
+
+The SDK has `McpTransport`, `McpClientTransport`, and `McpServerTransportProvider` concepts. Its 2.0 migration guide explicitly addresses developers implementing custom `McpClientTransport` or `McpServerTransportProvider`, including how transport implementations advertise supported protocol versions.
+
+Official code and examples use transport types independently of clients and servers, and server/client variants are intentionally separate because their hosting responsibilities differ.
+
+That client/server split is worth preserving. A server transport frequently owns a listener or framework adapter; a client transport is usually a dialer. Forcing them into one syntactically identical interface adds little value.
+
+**Assessment: Low.** Java needs convergence on a common MCP binding contract and tests, not a fundamental refactor.
+
+### Kotlin
+
+Kotlin is perhaps the best concrete evidence that “nonstandard MCP transport behind the same SDK” is already practical.
+
+Its current repository lists stdio, Streamable HTTP, legacy SSE, **WebSocket**, and an in-process `ChannelTransport`. A client creates a transport and passes it to `client.connect(transport)`. `ChannelTransport` provides a full-duplex connection over Kotlin coroutine channels.
+
+The WebSocket transport is particularly important to your question: **one official SDK has already demonstrated that MCP protocol handling does not inherently depend on Streamable HTTP.** The transport layer can be exchanged while the MCP client/server model remains intact.
+
+The caution is that parts of Kotlin's documentation still describe handshake/session-era MCP concepts while the latest core specification is stateless. That is a migration issue, not an argument against the architecture; a new cross-SDK transport contract should be defined against the 2026 binding semantics rather than copying legacy session assumptions.
+
+**Assessment: Low.**
+
+### C#
+
+C# has already gone through almost exactly the API design discussion SEP-2598 implies.
+
+An earlier SDK issue proposed changing `McpClientFactory.CreateAsync()` to receive an `IClientTransport` directly, with each transport owning its own configuration type. The proposed shape was:
+
+```csharp
+CreateAsync(
+    IClientTransport transport,
+    McpClientOptions? clientOptions = null,
+    ...)
+```
+
+and `StdioClientTransport` would implement `IClientTransport`. The discussion specifically recognized that transport state should be shifted toward per-client/session objects where possible.
+
+Current transport documentation also includes generic stream-based client/server transports in addition to HTTP and stdio, making arbitrary .NET `Stream` implementations usable as the underlying I/O mechanism.
+
+That already enables a large family of adapters without changing MCP: named pipes, custom sockets, encrypted streams, multiplexers, or a WebSocket abstraction presented as an appropriate stream/message adapter.
+
+**Assessment: Low.**
+
+### Go
+
+Go is the clearest “already solved” implementation.
+
+The official README says servers run over an `mcp.Transport`, clients connect through one, and explicitly states that the SDK's separate `jsonrpc` package exists **for users implementing their own transports**.
+
+The Go transport abstraction is also deliberately lightweight. The current `Transport` interface centers on `Connect(ctx)`, which returns a connection; lifecycle belongs primarily to the resulting connection rather than being forced onto the reusable transport factory. A proposal to add `Close()` directly to `Transport` was closed as not planned.
+
+That is a good design reference:
+
+```text
+Transport
+   = way to establish/open an MCP carrier
+
+Connection / Exchange
+   = stateful resource returned by that operation
+```
+
+It prevents a transport configuration/factory object from becoming synonymous with a specific MCP session—a particularly useful property now that MCP itself is stateless.
+
+**Assessment: Very low.** Go should probably be one of the reference SDKs for the proposed design.
+
+### PHP
+
+PHP documentation explicitly states: **“All transports implement the `TransportInterface`.”** A server accepts a transport through `Server::run($transport)`, with stdio and Streamable HTTP as concrete implementations.
+
+The client similarly constructs either `StdioTransport` or `HttpTransport` and passes it to `Client::connect()`.
+
+PHP's HTTP stack also illustrates another important principle: transport-specific concerns such as PSR-7 request handling, CORS, DNS-rebinding protection, HTTP protocol-version headers, body limits, and HTTP middleware belong in the HTTP transport implementation, not in the MCP protocol dispatcher.
+
+The main work is therefore updating the semantics of `TransportInterface` and implementations to the newer stateless protocol where required, not creating the extension seam itself.
+
+**Assessment: Low.**
+
+### Ruby
+
+Ruby is the largest architectural gap, although even here the client side already supports custom transports.
+
+The repository documents that callers may supply their own client transport provided it has the expected `send_request(request:)` behavior, taking a complete JSON-RPC request and returning the raw JSON-RPC response. The documentation explicitly names WebSocket and stdio as possible custom implementations.
+
+Server transports, however, are much more concrete. `StdioTransport` owns its read loop and is constructed with a server; `StreamableHTTPTransport` is directly a Rack application and dispatches into the server.
+
+That is workable for built-in transports but less attractive as a third-party SPI because it couples:
+
+```text
+hosting framework
++ transport lifecycle
++ message delivery
++ MCP server dispatch
+```
+
+A proper server binding interface should invert that dependency so the transport delivers an incoming MCP exchange into a server handler rather than embedding the server inside every transport implementation.
+
+**Assessment: Medium.** Ruby is the SDK where a deliberate server-side refactor would add the most value.
+
+### Rust
+
+Rust already states the desired design in almost exactly the requested language:
+
+> a transport moves JSON-RPC messages between client and server, and any `Transport` implementation can be supplied to `.serve(..)`.
+
+The SDK ships stdio, child-process, Streamable HTTP, and worker/in-process transports behind Cargo features.
+
+This is therefore already a genuine public transport SPI.
+
+One implementation concern for a browser-oriented `PostMessageTransport` is Rust/Wasm portability: transport implementations must avoid trait bounds or executor assumptions that unnecessarily require multithreaded `Send` futures where a browser's local event loop cannot satisfy them. That is an implementation-level issue, not a protocol limitation.
+
+**Assessment: Very low** for generic pluggability; browser/Wasm variants may require targeted ergonomic work.
+
+### Swift
+
+Swift likewise already exposes a public `Transport` protocol and provides complete documentation showing a user-defined:
+
+```swift
+public actor MyCustomTransport: Transport {
+    func connect() async throws
+    func disconnect() async
+    func send(_ data: Data) async throws
+    func receive() -> AsyncThrowingStream<Data, Error>
+}
+```
+
+The repository also includes an in-memory transport and a custom `NetworkTransport` using Apple's networking framework, in addition to stdio and HTTP.
+
+That is effectively the experiment SEP-2598 needed: a transport can already be replaced without changing the Swift MCP client/server APIs.
+
+**Assessment: Very low.**
+
+### What the ten SDKs collectively show
+
+There is no fundamental cross-language blocker.
+
+The APIs currently cluster into three patterns:
+
+| Pattern | SDK examples | Shape |
+|---|---|---|
+| Raw/message-stream transport | Python, Swift, Rust | transport sends/receives JSON-RPC messages or streams |
+| Transport → connection | Go, parts of Java/C# | reusable transport establishes a stateful carrier |
+| Framework/request adapter | TypeScript modern HTTP, PHP HTTP, Ruby Rack | each external request becomes an MCP exchange |
+
+All three are legitimate. The mistake would be requiring every language to expose **identical methods**.
+
+The cross-SDK requirement should therefore specify **behavior**, not syntax.
+
+## A transport interface that fits every SDK
+
+The right abstraction is slightly more precise than the historical idea of a generic bidirectional socket.
+
+I recommend defining an **MCP Binding SPI** whose public language-specific name may remain `Transport`, but whose normative unit is an **exchange**.
+
+### The logical model
+
+For modern MCP, the fundamental operation is:
+
+```text
+MCP request
+   │
+   │  contains protocol metadata
+   ▼
+┌───────────────────────────┐
+│ Transport / Binding       │
+│                           │
+│ establish carrier         │
+│ frame request             │
+│ send request              │
+│ receive response stream   │
+│ implement cancellation    │
+└───────────────────────────┘
+   │
+   ├── zero or more related notifications
+   │
+   └── final JSON-RPC response
+```
+
+A normal request may produce no intermediate notifications. A long-running operation may produce progress/log notifications followed by the result. `subscriptions/listen` is the same abstraction with a very long response stream. This follows the 2026 request-scoped model directly.
+
+A useful conceptual client API is therefore:
+
+```typescript
+interface McpClientTransport {
+    open(): Promise<void>;
+
+    exchange(
+        request: JsonRpcRequest,
+        options?: ExchangeOptions
+    ): AsyncIterable<JsonRpcResponse | JsonRpcNotification>;
+
+    sendNotification(
+        notification: JsonRpcNotification
+    ): Promise<void>;
+
+    close(): Promise<void>;
+}
+```
+
+This is **illustrative**, not a recommendation that every SDK adopt these exact methods.
+
+The important semantics are:
+
+```text
+exchange()
+    accepts a complete MCP JSON-RPC request
+    does not receive "requestId" separately
+    returns/yields messages belonging to that exchange
+    ends when the final response is delivered
+    exposes cancellation through the exchange/caller's cancellation primitive
+```
+
+The request ID remains part of the JSON-RPC message because the current protocol requires it, but **it should not become an extra transport abstraction parameter**. That satisfies the spirit of the SEP-2598 review concern: a transport API should not make protocol code manually correlate a separate `requestId` argument with an external channel.
+
+For a server, the inverse is more natural:
+
+```typescript
+interface McpServerTransport {
+    serve(
+        handler: (exchange: IncomingExchange) => Promise<void>
+    ): Promise<void>;
+
+    close(): Promise<void>;
+}
+
+interface IncomingExchange {
+    readonly request: JsonRpcRequest;
+    readonly transportContext?: unknown;
+
+    send(message: JsonRpcResponse | JsonRpcNotification): Promise<void>;
+}
+```
+
+Again, the exact language API should vary. Java may continue using `McpServerTransportProvider`; Go may return a `Connection`; Rust may model the exchange through traits and streams; Python may use async context managers; Ruby may use duck typing.
+
+### Why one universal `send()/onmessage` interface is not ideal
+
+A traditional transport interface such as:
+
+```text
+start
+send(message)
+onmessage(message)
+close
+```
+
+works beautifully for stdio, WebSocket, or MessagePort.
+
+It is less natural for modern Streamable HTTP because each MCP request owns its own HTTP response stream. The TypeScript SDK's current modern path demonstrates this directly by creating a per-request, single-exchange transport.
+
+Likewise, it is less natural for:
+
+```text
+gRPC unary request + server stream
+HTTP/2 request stream
+serverless invocation
+message queue request/reply
+RPC framework invocation
+```
+
+An **exchange-aware API can implement both models**, whereas a pure socket interface forces request-oriented transports to pretend they are connections.
+
+Internally:
+
+```text
+WebSocketTransport.exchange(request)
+    assign/send JSON-RPC request
+    route incoming frames by JSON-RPC id
+    yield matching notifications/response
+
+StdioTransport.exchange(request)
+    write line
+    route incoming lines by JSON-RPC id
+    yield matching messages
+
+HttpTransport.exchange(request)
+    POST request
+    yield SSE messages / JSON response
+
+GrpcCarrierTransport.exchange(request)
+    call RPC
+    put JSON-RPC document in payload
+    yield streamed JSON-RPC documents
+
+MessagePortTransport.exchange(request)
+    postMessage(JSON.stringify(request))
+    route MessageEvents by JSON-RPC id
+```
+
+That is a clean common denominator.
+
+### Connection should not equal MCP session
+
+The interface should also explicitly state:
+
+> **A transport connection is an I/O resource, not MCP protocol state.**
+
+That follows the 2026 specification's statelessness requirements. Servers cannot infer client capabilities, protocol version, task identity, conversation identity, or authorization state merely because requests arrived over the same connection.
+
+This single rule makes pooling safe conceptually:
+
+```text
+             ┌─ MCP request A
+WebSocket ───┼─ MCP request B
+connection   ├─ subscriptions/listen
+             └─ MCP request C
+```
+
+provided the binding correctly multiplexes the independent exchanges.
+
+It likewise permits:
+
+```text
+request A → gRPC channel 1
+request B → gRPC channel 2
+request C → gRPC channel 1
+```
+
+without changing MCP semantics.
+
+### Keep transport metadata opaque to the protocol core
+
+The current specification says all **protocol** metadata lives in the JSON-RPC body, while bindings may mirror information into envelope metadata such as HTTP headers. The body remains authoritative.
+
+Therefore the generic SPI should not contain fields such as:
+
+```text
+httpStatus
+requestHeaders
+responseHeaders
+stderr
+sseEventId
+webSocketCloseCode
+grpcMetadata
+origin
+messagePort
+```
+
+Those belong in transport-specific context or configuration.
+
+A generic escape hatch such as:
+
+```text
+TransportContext / TransportMetadata / NativeContext
+```
+
+can expose framework integration without making HTTP concepts part of MCP.
+
+PHP's HTTP middleware stack and TypeScript's HTTP request context demonstrate why this separation matters: HTTP-specific security, CORS, headers, authentication challenges, body limits, and framework request types have legitimate uses, but they are properties of that binding rather than properties of an MCP tool call.
+
+### Separate transport conformance from SDK tier conformance
+
+SEP-2598's proposal that every Tier-1 SDK maintain a reusable transport conformance harness attracted reasonable pushback because it multiplies implementation and review burden across languages.
+
+A cleaner arrangement would be:
+
+```text
+MCP core conformance
+    tests MCP semantics
+
+Binding conformance profile
+    tests JSON-RPC preservation
+    tests request/response association
+    tests streaming notifications
+    tests cancellation
+    tests malformed JSON-RPC
+    tests concurrent requests
+    tests subscriptions/listen
+    tests per-request metadata
+    tests teardown/error propagation
+
+SDK adapter
+    declares which binding profiles it passes
+```
+
+The important change is that the **test vectors and expected behavior should be centralized**, even if thin language-specific drivers are required.
+
+A third-party WebSocket package could then say:
+
+```text
+MCP WebSocket Binding Profile: PASS
+TypeScript adapter: PASS
+Go adapter: PASS
+Rust adapter: PASS
+```
+
+without making WebSocket itself mandatory for every Tier-1 SDK.
+
+That preserves the ecosystem flexibility the SEP reviewers wanted while still making “custom transport” mean something testable.
+
+## PostMessage, WebSocket, Cap’n Web, and RPC frameworks
+
+This narrower model opens the exact use cases in the question, but there is an important distinction between **carrying JSON-RPC through another system** and **replacing JSON-RPC with that system's native RPC model**.
+
+### PostMessageTransport
+
+A `PostMessageTransport` is one of the cleanest possible first reference implementations, particularly in TypeScript.
+
+Browser `MessagePort` is already message-framed and bidirectional. Conceptually:
+
+```text
+MCP Client
+   │
+   │ JSON.stringify(JSON-RPC)
+   ▼
+MessagePort.postMessage()
+   │
+   ▼
+iframe / Worker / extension / embedded app
+   │
+   │ JSON.parse()
+   ▼
+MCP Server
+```
+
+For strict conformity with the current MCP transport wording, the safest representation would be a **JSON text string containing the MCP JSON-RPC message**, rather than relying on structured-clone serialization of an arbitrary JavaScript object. MCP requires JSON-RPC messages and says they must be UTF-8 encoded; keeping the actual JSON document intact removes ambiguity about whether structured-clone objects constitute the required wire representation.
+
+`MessageChannel`/`MessagePort` is preferable to treating global `window.postMessage()` as an unrestricted bus because it naturally gives each side a dedicated endpoint. Where `window.postMessage()` is used directly, origin/source validation must be treated as part of the transport's security contract.
+
+An exchange implementation would be small:
+
+```typescript
+class MessagePortTransport {
+    constructor(private readonly port: MessagePort) {}
+
+    async send(message: JsonRpcMessage) {
+        this.port.postMessage(JSON.stringify(message));
+    }
+
+    // message event:
+    // 1. require string
+    // 2. JSON.parse
+    // 3. validate JSON-RPC
+    // 4. dispatch to matching exchange
+}
+```
+
+This would be an excellent SEP prototype because it demonstrates genuine value unavailable from stdio/HTTP while requiring **zero changes to MCP semantics**.
+
+It also enables important deployment structures:
+
+```text
+browser host ── MessagePort ── MCP implementation in Worker
+
+browser host ── postMessage ── sandboxed iframe MCP application
+
+VS Code / Electron renderer ── IPC/MessagePort ── MCP host
+
+extension content context ── message bridge ── privileged MCP context
+```
+
+### WebSocketTransport
+
+WebSocket is equally straightforward as a JSON-RPC-preserving binding.
+
+Kotlin already ships WebSocket support alongside the standard transports, explicitly describing it as full-duplex and low-latency.
+
+The natural framing is:
+
+```text
+one WebSocket text message
+        =
+one UTF-8 JSON-RPC document
+```
+
+That avoids introducing an unnecessary newline parser because WebSocket already provides message boundaries.
+
+The binding must define:
+
+```text
+connection establishment
+authentication
+maximum message size
+request multiplexing
+cancellation semantics
+connection closure
+reconnection behavior
+```
+
+as required by the custom-transport section of the MCP specification.
+
+A single WebSocket can multiplex many independent MCP requests. Request association remains internal to the binding by reading the JSON-RPC IDs; application-level MCP code need not know anything about the socket.
+
+This is therefore **not speculative**: Kotlin already demonstrates it, and the other SDKs' transport seams are sufficient to implement equivalents.
+
+### “cpanweb” appears to mean Cap'n Web
+
+The closest relevant technology to the term in the question is **Cap'n Web**, Cloudflare's JavaScript-native object-capability RPC system.
+
+Cap'n Web is particularly interesting here because it independently has the same transport-pluggability instinct: it works over HTTP, WebSocket, and `postMessage()` and allows additional transports.
+
+But Cap'n Web is **not JSON-RPC**.
+
+Its protocol uses its own JSON-based expression/array representation, is fully bidirectional, maintains import/export capability tables, and specifies a stream of discrete Cap'n Web RPC messages. WebSocket or `MessagePort` provides the message framing, while HTTP uses newline-separated Cap'n Web protocol messages.
+
+Therefore two integrations must be distinguished.
+
+#### Cap'n Web as an outer carrier
+
+This can fit the proposed first step:
+
+```text
+MCP JSON-RPC document
+       │
+       ▼
+Cap'n Web method:
+    sendMcp(jsonText)
+       │
+       ▼
+Cap'n Web transport
+    WebSocket/postMessage/HTTP
+       │
+       ▼
+sendMcp(jsonText)
+       │
+       ▼
+MCP JSON-RPC dispatcher
+```
+
+The JSON-RPC MCP message remains intact. Cap'n Web merely transports the string or bytes.
+
+This is conceptually compatible with the pluggable-binding idea, although it adds two layers of RPC framing and may not be worth the overhead unless Cap'n Web is already the application's communication fabric.
+
+#### MCP mapped natively onto Cap'n Web RPC
+
+For example:
+
+```text
+MCP tools/list
+      ↓ translated to
+capnwebApi.listTools()
+
+MCP tools/call
+      ↓ translated to
+capnwebApi.callTool(...)
+```
+
+is different.
+
+Here MCP JSON-RPC has disappeared, and Cap'n Web's native RPC protocol has become the actual representation. Under the current July 2026 MCP specification, that should **not** be presented merely as a custom MCP transport because custom transports must preserve JSON-RPC.
+
+That kind of semantic mapping is much closer to the broader version of SEP-2598 and would require reopening the question of alternate representations.
+
+This is precisely why separating the two projects is valuable.
+
+### gRPC and other RPC frameworks
+
+The same distinction applies to gRPC.
+
+A JSON-RPC-preserving gRPC carrier can be designed as something like:
+
+```protobuf
+message McpMessage {
+  bytes json_rpc_utf8 = 1;
+}
+
+service McpTransport {
+  rpc Exchange(McpMessage) returns (stream McpMessage);
+}
+```
+
+Then:
+
+```text
+JSON-RPC request
+      ↓
+protobuf envelope containing exact JSON bytes
+      ↓
+HTTP/2 / gRPC
+      ↓
+protobuf envelope
+      ↓
+same JSON-RPC messages
+```
+
+The RPC framework supplies:
+
+```text
+connection management
+TLS
+service discovery
+load balancing
+HTTP/2 multiplexing
+backpressure
+stream lifecycle
+deadlines
+```
+
+while MCP remains responsible for:
+
+```text
+JSON-RPC message shape
+MCP methods
+MCP metadata
+MCP results/errors
+MCP notifications
+```
+
+That is a strong use case for the proposed binding SPI.
+
+There is a subtle standards point here. The current specification clearly permits custom communication channels while requiring the JSON-RPC message representation to be preserved. An opaque RPC envelope containing the exact UTF-8 JSON-RPC document is therefore much more defensible than translating each JSON-RPC field into a native Protobuf service model; a future binding specification should make this encapsulation case explicit so implementors do not have to infer where “envelope” ends and “message format” begins.
+
+By contrast, this:
+
+```protobuf
+rpc ListTools(ListToolsRequest) returns (ListToolsResponse);
+rpc CallTool(CallToolRequest) returns (CallToolResponse);
+```
+
+with no JSON-RPC document transported is the kind of native gRPC mapping that generated the SEP-2598 review debate about request IDs and unsupported MCP features.
+
+It may be useful, but it is a **different protocol representation**, not merely a replaceable binding under today's specification.
+
+### The general rule
+
+A very useful line can therefore be drawn:
+
+| Mechanism | First-step pluggable transport? | Why |
+|---|---|---|
+| WebSocket carrying JSON-RPC text | **Yes** | Changes framing/channel only |
+| MessagePort carrying JSON-RPC text | **Yes** | Changes delivery mechanism only |
+| TCP/Unix socket carrying newline JSON-RPC | **Yes** | Explicitly encouraged by current spec |
+| Named pipe carrying stdio framing | **Yes** | Reliable byte-stream binding |
+| gRPC stream carrying opaque JSON-RPC documents | **Yes, with binding clarification advisable** | RPC framework is outer carrier |
+| NATS/AMQP request-reply carrying JSON-RPC documents | **Potentially yes** | Needs well-defined exchange/cancellation/ordering rules |
+| Cap'n Web call carrying an opaque MCP JSON document | **Yes in principle** | Cap'n Web is carrier, MCP remains JSON-RPC |
+| Native Cap'n Web method mapping of MCP | **No, not under current custom-transport rule** | Replaces JSON-RPC representation |
+| Native typed gRPC MCP service | **No, not as merely a custom transport today** | Transcodes MCP away from JSON-RPC |
+| CBOR/Protobuf representation of MCP messages | **No under current spec** | Exactly the requirement SEP-2598 proposed changing |
+
+That boundary is, in my view, the most important design simplification available now.
+
+## Adoption path and recommendation
+
+The strongest path forward is **not** a broad SEP saying “anything may be an MCP transport.” The current specification already says custom transports are possible. What is needed is a much narrower cross-SDK contract that makes the existing permission usable.
+
+### Define an SDK Binding SPI rather than a new protocol transport
+
+The proposal should establish approximately the following normative expectations:
+
+**An MCP SDK should provide a public extension point through which a third-party binding can deliver and receive complete MCP JSON-RPC messages without implementing or forking MCP protocol dispatch.**
+
+The binding extension point should:
+
+```text
+MUST accept/deliver complete MCP JSON-RPC messages
+
+MUST preserve per-request protocol metadata in those messages
+
+MUST support the MCP request/response message patterns required by
+the protocol versions it advertises
+
+MUST define cancellation and termination behavior
+
+MUST permit long-lived request response streams such as
+subscriptions/listen
+
+MUST NOT require connection identity to represent MCP session state
+
+MUST NOT expose HTTP- or stdio-specific concepts in its generic contract
+
+SHOULD hide request correlation inside the transport/exchange
+implementation rather than expose a separate request-id parameter
+
+MAY expose transport-specific/native context through a separate,
+opaque extension mechanism
+
+MAY pool or multiplex physical connections
+
+MAY be connection-oriented, request-oriented, or in-process
+```
+
+These requirements are derived directly from the current binding and statelessness rules rather than inventing new protocol semantics.
+
+### Do not require a single identical API across languages
+
+The SDK findings strongly argue against prescribing:
+
+```text
+interface Transport {
+    start()
+    send()
+    onMessage
+    close()
+}
+```
+
+everywhere.
+
+Instead, define semantic roles:
+
+```text
+                 MCP protocol core
+                        │
+                 Exchange abstraction
+                        │
+        ┌───────────────┴────────────────┐
+        │                                │
+ Client binding/dialer          Server binding/listener
+        │                                │
+   Transport-specific implementation
+```
+
+Each SDK can express this idiomatically:
+
+```text
+TypeScript       Promise / AsyncIterable
+Python           async context manager / streams
+Java             interfaces / publishers
+Kotlin           suspend functions / Flow / Channel
+C#               Task / IAsyncEnumerable
+Go               Transport → Connection
+PHP              interface + PSR-oriented adapters
+Ruby             duck-typed object / Enumerator
+Rust             traits / Stream
+Swift            protocol / AsyncThrowingStream
+```
+
+Cross-SDK interoperability depends on the **wire behavior**, not on matching method names.
+
+### Use PostMessage as the first prototype
+
+A TypeScript `MessagePortTransport` would be an unusually effective prototype because it proves all of the architectural claims while remaining small:
+
+```text
+@modelcontextprotocol/core
+        │
+        ├── standard stdio
+        ├── standard Streamable HTTP
+        │
+        └── external @mcp/transport-messageport
+                       │
+                       └── MessagePort / Worker / iframe
+```
+
+It would exercise:
+
+```text
+third-party package boundaries
+JSON-RPC message validation
+transport injection
+bidirectional delivery
+parallel requests
+long-lived subscriptions
+cancellation
+closure
+browser security
+no HTTP assumptions
+no process assumptions
+```
+
+and unlike a native gRPC implementation, it would not reopen the alternate-serialization debate.
+
+Kotlin's existing WebSocket implementation can simultaneously function as evidence that the same conceptual extension works outside TypeScript.
+
+### Use Go and Rust as reference SPI implementations
+
+Go and Rust are useful second reference points because both already explicitly treat transport as an extension seam.
+
+Go's SDK says its `jsonrpc` package exists for custom transports and cleanly separates `Transport` from the resulting connection.
+
+Rust says directly that any `Transport` implementation may be passed to `.serve(..)`.
+
+A cross-SDK proposal built around **TypeScript + Go + Rust**, rather than merely one SDK, would demonstrate that the contract survives:
+
+```text
+dynamic typed event-driven runtime
+garbage-collected systems language
+ownership/trait-based systems language
+```
+
+before asking every official SDK to conform.
+
+### Then align the other SDKs incrementally
+
+The adoption work is primarily convergence:
+
+| SDK | Recommended first change |
+|---|---|
+| TypeScript | Publicly document/stabilize the transport/binding SPI that bridges normal connections and modern single-exchange serving. |
+| Python | Promote the existing client `Transport` concept and add an equally clean modern server-binding entry point. |
+| Java | Document existing `McpClientTransport`/server provider APIs as the official third-party binding SPI and run common conformance vectors. |
+| Kotlin | Treat existing WebSocket/Channel abstractions as the reference for custom transports and align semantics with 2026 stateless MCP. |
+| C# | Formalize `IClientTransport` plus the corresponding server transport semantics as the extension surface. |
+| Go | Largely no architectural change; document as a reference model. |
+| PHP | Promote existing `TransportInterface` as third-party SPI and remove legacy session assumptions from the modern binding profile. |
+| Ruby | Introduce a server-side binding/exchange contract so custom servers do not have to embed the MCP server inside a Rack/stdio-style transport. |
+| Rust | Largely no architectural change; ensure executor/Wasm constraints do not unnecessarily block browser transports. |
+| Swift | Largely no architectural change; document conformance requirements for custom `Transport` implementations. |
+
+Those conclusions follow the existing SDK interfaces rather than requiring ten independent redesigns.
+
+### The important architectural boundary
+
+The resulting architecture would look like this:
+
+```text
+                         MCP application API
+                                │
+                    tools / resources / prompts
+                                │
+                        MCP protocol engine
+                                │
+                  MCP JSON-RPC message objects
+                                │
+                     Public Binding / Transport SPI
+                                │
+       ┌─────────────┬──────────┼───────────┬──────────────┐
+       │             │          │           │              │
+     stdio     Streamable     WebSocket   MessagePort   RPC carrier
+                 HTTP                                    │
+                                                        ├─ gRPC
+                                                        ├─ Cap'n Web
+                                                        ├─ custom IPC
+                                                        └─ message bus
+```
+
+With a critical rule at the bottom:
+
+```text
+                    ╔════════════════════════╗
+                    ║ JSON-RPC stays intact ║
+                    ╚════════════════════════╝
+```
+
+That boundary gives MCP transport pluggability **without making every alternate network technology a new MCP protocol**.
+
+### Bottom line
+
+The answer to the central question is therefore **yes, with one design correction**:
+
+**Expose a replaceable MCP binding/transport seam, but standardize it around independent JSON-RPC exchanges rather than around Streamable HTTP or around a generic persistent socket.**
+
+That approach is feasible across all ten SDKs because most already contain the necessary abstraction. Go, Java, C#, PHP, Rust, Swift, Kotlin, and Python provide especially strong existing foundations; TypeScript has the right injection points but needs its modern per-request model reflected in the public extension story; Ruby requires the most server-side decoupling.
+
+**WebSocket and PostMessage/MessagePort are natural conforming examples.** Kotlin's existing WebSocket support already demonstrates the former, while the latter is particularly well suited to browser, worker, iframe, Electron, and extension environments.
+
+**An RPC framework can also sit underneath this seam**, provided it acts as a carrier for the existing MCP JSON-RPC document. A gRPC stream carrying opaque UTF-8 JSON-RPC payloads fits the proposed first step far better than a typed Protobuf re-expression of every MCP operation.
+
+**Cap'n Web can similarly wrap MCP JSON-RPC, and it is especially interesting because it already supports HTTP, WebSocket, and `postMessage()`. But mapping MCP directly onto Cap'n Web's native object-capability calls would cross the line from “pluggable binding” into “alternate MCP representation,” because Cap'n Web has its own RPC protocol rather than JSON-RPC.**
+
+Most importantly, the July 28, 2026 stateless MCP redesign removed much of the connection/session coupling that made SEP-2598 difficult to reason about in April. Requests now carry their own protocol context, long-lived streams belong to requests rather than sessions, and transport connections are explicitly not protocol state.
+
+So the most viable successor to SEP-2598 is not:
+
+> “Allow arbitrary alternative encodings and require every Tier-1 SDK to implement a universal transport abstraction.”
+
+It is:
+
+> **“Define an SDK-level Binding SPI for carrying unchanged MCP JSON-RPC over custom communication mechanisms; make exchange scoping, cancellation, streaming, and per-request metadata the common semantics; let each SDK expose that SPI idiomatically; and validate third-party bindings with centralized conformance vectors.”**
+
+That is narrow enough to implement now, compatible with the current MCP specification, substantially already implemented across the official SDK family, and sufficient to unlock `PostMessageTransport`, WebSocket transports, JSON-RPC-over-gRPC, local IPC, and other RPC/framework carriers without waiting for MCP to standardize each one individually.

--- a/docs/pluggable/rpc-transports-research-report.md
+++ b/docs/pluggable/rpc-transports-research-report.md
@@ -1,0 +1,725 @@
+# MCP RPC Transport Pluggability Across the Official SDKs
+
+## Executive summary
+
+**Conclusion: a JSON-RPC-preserving `Transport` extension point is technically feasible across all ten MCP SDKs, and it is a substantially lower-risk first step than the broader version of SEP-2598.** The strongest evidence is that much of the ecosystem already works this way: TypeScript, Java, Kotlin, C#, Go, Rust, and Swift expose explicit transport abstractions; PHP exposes a transport interface but mixes message and HTTP/session concerns; Ruby has transport base classes tied closely to its server runtime; and Python's equivalent abstraction is a pair of typed AnyIO streams carrying `SessionMessage`.
+
+More importantly, **the current MCP 2026-07-28 specification has moved toward exactly the narrower boundary contemplated here**. It says MCP messages are JSON-RPC, allows custom transports, says protocol semantics are identical across transports, and requires custom transports to preserve the JSON-RPC message format, message patterns, and per-request metadata model. The spec identifies framing, delivery, cancellation, and termination as transport/binding responsibilities—not MCP method semantics.
+
+That makes the recommended architectural line:
+
+> **Transport = carry complete MCP JSON-RPC messages over another carrier.**
+> **Native RPC binding = translate MCP operations into another RPC system's native methods/types/capabilities.**
+
+The first category cleanly covers WebSocket, SSH, Unix/TCP streams, `postMessage`/`MessagePort`, in-process channels, a gRPC bidirectional JSON-RPC tunnel, or an RPC-framework tunnel. The second category includes mapping `tools/call` directly onto a protobuf RPC method or mapping MCP entities onto native Cap'n Web object capabilities; that is a different and harder problem. SEP-1319 deliberately decoupled request/result payload schemas from JSON-RPC wrappers in order to make such future native bindings possible without changing today's JSON wire representation.
+
+The most persuasive reference implementation already exists: **MCP Apps' `PostMessageTransport` is merged code in the official `modelcontextprotocol/ext-apps` repository.** It implements the TypeScript SDK's `Transport`, accepts and emits `JSONRPCMessage`, validates incoming messages against the JSON-RPC schema, and carries them through `window.postMessage`. The accompanying MCP Apps specification explicitly chose MCP JSON-RPC over `postMessage` instead of inventing a separate UI protocol.
+
+There is also real evidence for the RPC-framework direction. Cloudflare's Agents SDK has an `RPCServerTransport` used by `McpAgent`; a 2026 issue describes MCP JSON-RPC responses being carried through that RPC path and exposes a concurrency bug caused by keeping only one pending response resolver. The issue was assigned to Matt Carey. That bug is particularly useful evidence: **an RPC carrier works, but transport conformance must explicitly test overlapping requests and response correlation.**
+
+SEP-2598 was therefore directionally right but broader than necessary. It proposed both a mandatory Tier-1 SDK interface/conformance harness **and** permitting custom transports to transcode JSON-RPC into other encodings as long as a bidirectional mapping existed. Reviewers objected to the conformance burden, over-prescriptive cross-language API requirements, and semantic assumptions that do not fit native gRPC—for example request IDs, `initialize`, cancellation notifications, and exhaustive feature mappings. The PR remains open but was moved to **Deferred** in May 2026.
+
+The recommended first step is consequently narrower:
+
+**standardize the semantic contract of a JSON-RPC message transport, not a universal language API and not native-RPC translation; use the existing MCP Apps `PostMessageTransport` as prototype zero; extract/generalize it; and validate it with a transport-neutral conformance checklist.**
+
+## Landscape, proposals, and timeline
+
+The history shows three different lines of work gradually converging.
+
+The first line proposed additional concrete wire mechanisms—WebSocket, gRPC, and SSH. The second line, SEP-1319, separated MCP data payloads from the JSON-RPC wrapper so native bindings could eventually exist. The third line, SEP-2598, tried to generalize transport extensibility itself. In parallel, SDKs independently accumulated transport interfaces, in-memory adapters, WebSocket implementations, TCP/UDP adapters, and finally the official MCP Apps `PostMessageTransport`.
+
+```mermaid
+timeline
+    title MCP transport and RPC-pluggability milestones
+
+    2025-07-14 : gRPC transport issue #966 opened
+    2025-08-02 : SEP-1288 WebSocket proposal
+    2025-08-08 : SEP-1319 payload/RPC decoupling
+    2025-08-15 : SEP-1352 gRPC proposal
+    2026-01-26 : MCP Apps specifies JSON-RPC over postMessage
+    2026-03-01 : SEP-2325 SSH custom transport opened
+    2026-04-17 : SEP-2598 Pluggable Transports opened
+    2026-04-25 : mcp-grpc-transport cited in SEP-2598
+    2026-05-05 : SEP-2598 moved to Deferred
+    2026-05-16 : Cloudflare RPCServerTransport concurrency issue
+    2026-06-08 : SEP-2325 SSH proposal closed
+    2026-07-28 : MCP spec explicitly retains JSON-RPC for custom transports
+```
+
+The original [gRPC standard-transport issue #966](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/966), opened by Kurtis Van Gent on July 14, 2025, proposed protobuf/gRPC over HTTP/2 as an MCP transport. SEP-1352 later developed that direction in more detail and contemplated implementations supporting JSON-RPC, gRPC, or both.
+
+[SEP-1288](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1288), opened by Larry Maccherone on August 2, 2025, proposed WebSocket as a full-duplex MCP transport. The proposal evolved away from adding a separate envelope and toward carrying MCP messages directly. It is now closed/dormant rather than part of the standard transport set.
+
+[SEP-1319](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1319), opened by Kurtis Van Gent on behalf of the Transport Working Group on August 8, 2025, is particularly important architecturally. It separated payload types such as call parameters/results from the JSON-RPC method wrapper while explicitly leaving existing JSON wire representations unchanged. GitHub now labels the SEP accepted/final.
+
+[SEP-2325](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2325), authored by `@tobert` beginning March 1, 2026, proposed SSH as an informational custom transport. It documented SSH subsystem and embedded-SSH-server models and observed that an existing stdio MCP server can run as an SSH subsystem using the same newline JSON framing. The PR linked a Go SDK branch, an example server, and a stdio-to-SSH shim. It was closed by the author on June 8, 2026 because interest had stalled, not because the implementation approach was shown invalid.
+
+[SEP-2598](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2598), opened by Kurtis Van Gent on April 17, 2026, attempted to consolidate these threads. It proposed keeping only stdio and Streamable HTTP as standard transports, requiring Tier-1 SDKs to expose an extension interface and reusable conformance harness, and letting concrete transports ship independently or as extensions. It also proposed permitting custom transports to transcode JSON-RPC into protobuf, CBOR, or other representations, provided the MCP semantics could be mapped back.
+
+That last part produced the deepest disagreement. Mark Roth pointed out that a native gRPC transport may not have a JSON-RPC request ID at all, may not support `notifications/cancelled`, and may not implement a stateful `initialize`; he therefore argued against requiring every field and operation to round-trip through a generalized JSON-RPC transport abstraction. The same review also raised the need for an API that associates responses with carrier-level requests without exposing JSON-RPC IDs as the routing mechanism.
+
+There was separate pushback on process: `@pcarleton` argued that requiring every Tier-1 SDK to build and maintain its own transport conformance harness would impose a significant burden and suggested transport extensions instead plug into optional centralized conformance tests. `@halter73` likewise cautioned against forcing identical interface shapes onto languages that already had idiomatic abstractions.
+
+Those objections become much easier to accommodate if the first SEP says only:
+
+> An SDK should expose an idiomatic extension point through which complete MCP JSON-RPC messages can be sent and received; the method names and concurrency primitive are language-specific.
+
+The current 2026-07-28 transport specification strongly supports that narrower interpretation: only stdio and Streamable HTTP are standard, custom transports are allowed, and custom transports must preserve JSON-RPC and MCP message patterns.
+
+## Catalog of discovered transports, proposals, forks, and adapters
+
+The table distinguishes **carrier transports**, which preserve MCP JSON-RPC messages, from **native-RPC proposals**, which translate MCP semantics into another RPC model.
+
+| Artifact | Link | Author / owner | Date | Status | SDK / language | What it demonstrates |
+|---|---|---|---|---|---|---|
+| SEP-1288 WebSocket Transport | [modelcontextprotocol #1288](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1288) | Larry Maccherone (`@lmaccherone`) | 2025-08-02 | Proposal issue; closed/dormant | Protocol / cross-language | Full-duplex WebSocket carrier for MCP; evidence of demand for a non-HTTP persistent transport. |
+| gRPC standard transport | [modelcontextprotocol #966](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/966) | Kurtis Van Gent | 2025-07-14 | Issue; closed | Protocol / gRPC | Early proposal for protobuf/gRPC as a standard MCP transport. |
+| SEP-1319 payload/RPC decoupling | [modelcontextprotocol #1319](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1319) | Kurtis Van Gent, Transport WG | 2025-08-08 | Accepted/final issue | Protocol | Separates payload schemas from JSON-RPC wrappers, intentionally without changing current wire JSON; foundation for future native bindings. |
+| SEP-1352 gRPC | [modelcontextprotocol #1352](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1352) | Kurtis Van Gent, Mark Roth, Harvey Tuch | 2025-08-15 | Proposal issue; closed; proposal text Draft | Protocol / gRPC | More explicit native gRPC/protobuf MCP binding, with JSON-RPC/gRPC coexistence considered. |
+| MCP Apps `PostMessageTransport` | [ext-apps `message-transport.ts`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/message-transport.ts) | Author unspecified in retrieved file metadata; MCP Apps maintainers | implementation date unspecified; spec snapshot 2026-01-26 | **Merged/main** | TypeScript | Implements the SDK `Transport`; sends and validates `JSONRPCMessage` through browser `postMessage`. This is the strongest existing prototype for pluggability. |
+| SEP-2325 SSH Custom Transport | [modelcontextprotocol PR #2325](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2325) | `@tobert` | 2026-03-01 | PR/fork branch; closed 2026-06-08 | Protocol + Go reference work | SSH subsystem/embedded-server designs, stdio-compatible JSON framing, Go branch, example server and stdio↔SSH shim. |
+| SEP-2598 Pluggable Transports | [modelcontextprotocol PR #2598](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2598) | Kurtis Van Gent (`@kurtisvg`) | 2026-04-17 | **Open PR; Deferred** | Cross-SDK | Proposed public SDK extension point + conformance harness + independent transport packages; also proposed alternate encodings, which drew semantic objections. |
+| `mcp-grpc-transport` | [ClawQL package source](https://github.com/danielsmithdevelopment/ClawQL/tree/main/packages/mcp-grpc-transport) | Daniel Smith / `@danielsmithdevelopment` | repo date unspecified; referenced 2026-04-25 | Third-party package / main | TypeScript / gRPC | Native protobuf service plus an **optional bidirectional JSON-RPC fallback stream**. The latter is exactly the JSON-RPC tunnel pattern. |
+| Cloudflare Agents `RPCServerTransport` | [cloudflare/agents issue #1540](https://github.com/cloudflare/agents/issues/1540) | implementation author unspecified; issue assigned to Matt Carey | implementation date unspecified; issue 2026-05-16 | Existing implementation; bug issue closed with linked fix work | TypeScript / Cloudflare RPC | `McpAgent` transports MCP through Cloudflare's RPC path. Concurrency bug demonstrates why a transport harness must test simultaneous requests and correlation. |
+| Cap'n Web `RpcTransport` | [cloudflare/capnweb](https://github.com/cloudflare/capnweb) | Cloudflare | unspecified | Merged/main | TypeScript | Generic bidirectional `send(string)` / `receive(): string` RPC transport. It can underlie an MCP JSON-RPC tunnel, although no verified public MCP `CapnWebTransport` adapter was found in this research. |
+| Kotlin WebSocket transport | [kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk) | MCP/JetBrains Kotlin SDK maintainers | unspecified | Merged/main | Kotlin | Current README explicitly exposes WebSocket among SDK transports, proving the existing `Transport` interface supports non-HTTP carriers. |
+| Python WebSocket client | [python-sdk `client/websocket.py`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/websocket.py) | Python SDK maintainers | unspecified | Merged/main | Python | Returns the same `SessionMessage` read/write stream pair as stdio/HTTP transports; excellent evidence that Python already has a transport-neutral message seam. |
+| TypeScript legacy WebSocket client | [v2 migration guide](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/upgrade-to-v2.md) | TypeScript SDK maintainers | v2 migration, current main | Removed from v2 core; custom interface remains | TypeScript | `WebSocketClientTransport` was intentionally removed because WebSocket is not a standard spec transport, while the public `Transport` interface was retained specifically for custom implementations. |
+| Swift `NetworkTransport` | [swift-sdk `NetworkTransport.swift`](https://github.com/modelcontextprotocol/swift-sdk/blob/main/Sources/MCP/Base/Transports/NetworkTransport.swift) | Swift SDK maintainers | unspecified | Merged/main | Swift | Custom transport over Apple's Network framework supporting TCP/UDP; demonstrates that the raw-`Data` transport interface is already carrier-pluggable. |
+| Go `InMemoryTransport` | [go-sdk `mcp/transport.go`](https://github.com/modelcontextprotocol/go-sdk/blob/main/mcp/transport.go) | Go SDK maintainers | unspecified | Merged/main | Go | `NewInMemoryTransports()` creates interconnected client/server transports on the same message abstraction; ideal conformance-test baseline. |
+| Kotlin `ChannelTransport` | [kotlin-sdk `ChannelTransport.kt`](https://github.com/modelcontextprotocol/kotlin-sdk/blob/main/kotlin-sdk-testing/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/testing/ChannelTransport.kt) | Kotlin SDK maintainers | unspecified | Merged/main; experimental/testing | Kotlin | Uses coroutine `Channel<JSONRPCMessage>` pairs; explicit in-process message transport with no network layer. |
+| TypeScript `InMemoryTransport` | [v2 migration documentation](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/upgrade-to-v2.md) | TypeScript SDK maintainers | unspecified | Merged/main/exported | TypeScript | Linked in-memory pair used extensively in examples/tests; proves MCP core is already independent of actual networking. |
+| PHP Protocol/Transport decoupling | [php-sdk PR #160](https://github.com/modelcontextprotocol/php-sdk/pull/160) | `@lvluoyue` | unspecified | Merged | PHP | Made `Protocol` stateless with respect to `TransportInterface`, removed `getTransport()`, and passes transport to processing instead; useful preparatory refactor for pluggability. |
+
+### The requested Matt Carey / Cap'n Web branch evidence
+
+I could verify two closely related primary-source facts, but **not** the specific public branch/fork names `rpctransport` or `capnwebtransport`.
+
+First, Cloudflare Agents has an MCP `RPCServerTransport`; issue #1540 describes `McpAgent` using it and was assigned to Matt Carey. Second, Cloudflare's Cap'n Web exposes a generic `RpcTransport` abstraction whose contract is a bidirectional stream of complete string messages.
+
+Direct searches for a public `mattzcarey/typescript-sdk` branch named `rpctransport` or `capnwebtransport`, and for an indexed `CapnWebTransport` MCP class, did not return a verifiable primary-source artifact. Those entries should therefore be treated as **unverified / link unspecified**, rather than inferred from the Cloudflare Agents implementation. They are high-priority items for direct GitHub branch/fork search or a question to Matt Carey.
+
+## SDK transport seams and feasibility
+
+The cross-SDK result is stronger than SEP-2598's wording might suggest: **the work is mostly API normalization/documentation, not a ground-up refactor.**
+
+| SDK | Current seam and verified path | Message boundary | Effort | Breaking-change risk | Recommended language-specific shape |
+|---|---|---|---|---|---|
+| **TypeScript** | [`packages/core-internal/src/shared/transport.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/core-internal/src/shared/transport.ts) | `JSONRPCMessage` | **Low** | Low if additive | Keep `Transport`; split transport-neutral context/capabilities from HTTP-specific `TransportSendOptions`. |
+| **Python** | [`src/mcp/client/websocket.py`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/websocket.py), stdio/HTTP clients, `ClientSession` stream constructor | `SessionMessage` over AnyIO memory streams | **Low–Medium** | Very low if streams remain supported | Add an idiomatic `Protocol`/async-context-manager factory returning `(ReadStream, WriteStream[, metadata])`; do not force callback OO style. |
+| **Java** | [`McpTransport.java`](https://github.com/modelcontextprotocol/java-sdk/blob/main/mcp-core/src/main/java/io/modelcontextprotocol/spec/McpTransport.java) | `JSONRPCMessage` | **Very low** | Very low | Treat existing `McpTransport` plus client/server refinements as the extension point; document conformance semantics. |
+| **Kotlin** | [`shared/Transport.kt`](https://github.com/modelcontextprotocol/kotlin-sdk/blob/main/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Transport.kt) | `JSONRPCMessage` | **Very low** | Very low | Existing `suspend` API is essentially the target contract; use `AbstractTransport` helpers and coroutine callbacks/channels. |
+| **C#** | [`ITransport.cs`](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.Core/Protocol/ITransport.cs) | `JsonRpcMessage` + `ChannelReader` | **Very low** | Very low | Keep `IClientTransport.ConnectAsync → ITransport`; use channels for receive and `SendMessageAsync` for send. |
+| **Go** | [`mcp/transport.go`](https://github.com/modelcontextprotocol/go-sdk/blob/main/mcp/transport.go) | `jsonrpc.Message` | **Very low** | Low; only legacy `SessionID()` cleanup could break | Existing `Transport.Connect → Connection{Read,Write,Close}` is arguably the cleanest reference design. |
+| **PHP** | [`src/Server/Transport/TransportInterface.php`](https://github.com/modelcontextprotocol/php-sdk/blob/main/src/Server/Transport/TransportInterface.php) | serialized `string` plus context | **Medium** | Medium if existing interface changed directly | Add a new typed/message-level `MessageTransportInterface`; adapt existing execution-oriented `TransportInterface` rather than breaking it. |
+| **Ruby** | [`lib/mcp/server/transports/streamable_http_transport.rb`](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/lib/mcp/server/transports/streamable_http_transport.rb), [`lib/mcp/server.rb`](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/lib/mcp/server.rb) | Hash/JSON strings, strongly server-oriented | **Medium–High** | Low if new abstraction is additive | Introduce a small duck-typed `MessageTransport`/base class and adapters around current stdio/HTTP transports; keep Rack-specific dispatch separate. |
+| **Rust** | [`crates/rmcp/src/transport.rs`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/crates/rmcp/src/transport.rs) | role-typed `TxJsonRpcMessage` / `RxJsonRpcMessage` | **Very low** | Very low | Existing `Transport<R>` + `IntoTransport` is already ideal; preserve generic `Sink`/`Stream` and `AsyncRead`/`AsyncWrite` adapters. |
+| **Swift** | [`Sources/MCP/Base/Transport.swift`](https://github.com/modelcontextprotocol/swift-sdk/blob/main/Sources/MCP/Base/Transport.swift) | raw `Data` | **Low–Medium** | Very low if layered | Retain byte-level `Transport`; add a typed JSON-RPC adapter/protocol above it instead of replacing the existing abstraction. |
+
+### Representative API shapes
+
+TypeScript is already explicitly documented as the minimal MCP transport contract. In abridged form its shape is:
+
+```ts
+interface Transport {
+  start(): Promise<void>;
+  send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void>;
+  close(): Promise<void>;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+}
+```
+
+The important point is not those exact names; it is that **decoded JSON-RPC messages cross the boundary**.
+
+The weakness is that TypeScript's generic `TransportSendOptions` has acquired Streamable-HTTP-oriented concepts such as related request IDs, per-request stream behavior, resumption controls, cancellation signals, and headers. That is precisely where an incremental cleanup can improve pluggability without changing the underlying protocol abstraction.
+
+Go provides an even cleaner split:
+
+```go
+type Transport interface {
+    Connect(context.Context) (Connection, error)
+}
+
+type Connection interface {
+    Read(context.Context) (jsonrpc.Message, error)
+    Write(context.Context, jsonrpc.Message) error
+    Close() error
+}
+```
+
+The SDK itself describes `Connection` as a logical bidirectional JSON-RPC connection. Its only notable historical leak is `SessionID()`, which already carries a TODO for removal.
+
+Rust is similarly direct:
+
+```rust
+trait Transport<R> {
+    fn send(&mut self, msg: TxJsonRpcMessage<R>) -> ...;
+    fn receive(&mut self) -> ... Option<RxJsonRpcMessage<R>>;
+    fn close(&mut self) -> ...;
+}
+```
+
+`IntoTransport` lets normal Rust `Sink`/`Stream` and async reader/writer types become MCP transports, making WebSocket-, TCP-, pipe-, and in-process-style adapters natural.
+
+Kotlin's public interface is almost isomorphic to TypeScript:
+
+```kotlin
+interface Transport {
+    suspend fun start()
+    suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?)
+    suspend fun close()
+    fun onMessage(block: suspend (JSONRPCMessage) -> Unit)
+}
+```
+
+Its testing package then proves the abstraction with `ChannelTransport`, whose send and receive sides are coroutine channels of `JSONRPCMessage`.
+
+C# naturally expresses the same idea through channels:
+
+```csharp
+interface ITransport : IAsyncDisposable {
+    ChannelReader<JsonRpcMessage> MessageReader { get; }
+    Task SendMessageAsync(JsonRpcMessage message, CancellationToken ct = default);
+}
+```
+
+The transport represents an already-established session, while `IClientTransport` handles establishment. That separation between **transport factory** and **connected message channel** is worth copying conceptually in languages where connection creation is complex.
+
+Python is different syntactically but not architecturally. Its WebSocket and HTTP/stdio adapters ultimately produce typed AnyIO streams approximately equivalent to:
+
+```python
+(
+    MemoryObjectReceiveStream[SessionMessage | Exception],
+    MemoryObjectSendStream[SessionMessage],
+)
+```
+
+`ClientSession` consumes those streams rather than a nominal `Transport` object. That is already pluggability; what is missing is primarily a named, documented extension contract.
+
+Swift sits one layer lower:
+
+```swift
+public protocol Transport: Actor {
+    func connect() async throws
+    func disconnect() async
+    func send(_ data: Data) async throws
+    func receive() -> AsyncThrowingStream<Data, Swift.Error>
+}
+```
+
+This explains why a TCP/UDP `NetworkTransport` is already easy to provide, but also why a reusable custom-transport ecosystem would benefit from a typed JSON-RPC codec/adapter immediately above this protocol.
+
+PHP is the clearest case where **a second, narrower abstraction is preferable to changing the existing one**. Its current `TransportInterface` controls initialization/listening and sends serialized strings with a context that can include `session_id`, message type, and HTTP status codes. That interface serves the server runtime well, but HTTP status codes are exactly the kind of carrier-specific concept that a reusable JSON-RPC message transport should avoid.
+
+The already-merged PHP PR #160 helps: the SDK made `Protocol` stateless with respect to the transport, removed `Protocol::getTransport()`, and passes the transport into message processing. That is a useful preparatory decoupling for introducing a cleaner message-level adapter later.
+
+Ruby has a similar but stronger coupling problem. `StreamableHTTPTransport` subclasses `Transport`, acts as a Rack application, owns session/request stream routing, and delegates parsed JSON-RPC into `MCP::Server#handle`. The protocol/server code is therefore separable from JSON parsing, but the current transport objects combine network ingress, session state, Rack semantics, and server dispatch. An additive `MessageTransport` adapter would be safer than rewriting the current classes.
+
+## Concrete transport patterns and the Transport-versus-Binding boundary
+
+The central architectural recommendation is to separate **MCP JSON-RPC-preserving carrier bindings** from **native RPC semantic bindings**.
+
+The current MCP spec itself uses the word *binding* for how a transport frames and delivers MCP messages. To avoid terminology ambiguity, the diagram below uses **carrier binding** for that spec concept and **native-RPC binding** for translating MCP operations into another RPC system's native API.
+
+```mermaid
+flowchart TB
+    C[MCP Client / Server API]
+    J[MCP JSON-RPC message layer]
+
+    C --> J
+
+    J --> T[SDK Transport extension point]
+
+    T --> PM[postMessage / MessagePort]
+    T --> WS[WebSocket]
+    T --> SSH[SSH / stdio framing]
+    T --> TCP[TCP / Unix socket / pipes]
+    T --> GRPCT[gRPC JSON-RPC tunnel]
+    T --> CWT[Cap'n Web / RPC-framework tunnel]
+    T --> MEM[In-memory channel]
+
+    C --> P[Transport-agnostic MCP payload models]
+    P --> NB[Native-RPC binding]
+    NB --> GRPCN[Native protobuf / gRPC methods]
+    NB --> CAPNN[Native Cap'n Web objects/capabilities]
+
+    classDef conceptual stroke-dasharray: 5 5
+    class NB,GRPCN,CAPNN conceptual
+```
+
+### PostMessageTransport
+
+This case is no longer hypothetical.
+
+The official MCP Apps repository has:
+
+[`modelcontextprotocol/ext-apps/src/message-transport.ts`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/message-transport.ts)
+
+Its `PostMessageTransport` directly implements the TypeScript MCP SDK's `Transport`. It validates incoming `event.data` with `JSONRPCMessageSchema`, calls `onmessage` with the parsed `JSONRPCMessage`, and sends outgoing JSON-RPC objects through `postMessage`.
+
+Conceptually:
+
+```ts
+class PostMessageTransport implements Transport {
+  async start() {
+    window.addEventListener("message", this.listener);
+  }
+
+  async send(message: JSONRPCMessage) {
+    this.target.postMessage(message, targetOrigin);
+  }
+
+  async close() {
+    window.removeEventListener("message", this.listener);
+  }
+}
+```
+
+That is almost the ideal prototype because nothing in `Client` or `Server` needs to know that the carrier is a browser frame instead of stdio or HTTP.
+
+The MCP Apps specification independently documents the design decision to use **MCP's JSON-RPC base protocol over `postMessage`** rather than a separate UI message format, specifically to reuse existing MCP types, errors, timeouts, and future protocol features.
+
+There is one refinement worth making if this code becomes the general transport prototype. The current implementation validates `event.source`, but its outgoing call uses `"*"` as the target origin. A generic reusable transport should support an explicit `targetOrigin` and, where deployment permits, verify both the expected source and origin.
+
+There is also a subtle specification issue worth resolving explicitly. The 2026-07-28 base transport page says JSON-RPC messages must be UTF-8 encoded, while the MCP Apps implementation sends a structured JavaScript object through structured clone rather than a textual byte stream. A transport-pluggability clarification could therefore define the **SDK boundary** in terms of a validated `JSONRPCMessage` object while allowing carrier-specific serialization—UTF-8 JSON for byte-stream/WebSocket/gRPC tunnels, structured clone for `postMessage`, and so on—provided the JSON-RPC value is preserved.
+
+### WebSocket
+
+WebSocket fits the narrow transport definition almost perfectly.
+
+```mermaid
+sequenceDiagram
+    participant MCP as MCP Protocol
+    participant T as WebSocketTransport
+    participant WS as WebSocket
+    participant P as Peer Transport
+
+    MCP->>T: JSONRPCMessage
+    T->>WS: one serialized JSON-RPC message
+    WS->>P: text frame
+    P-->>WS: text frame
+    WS-->>T: parse JSON-RPC
+    T-->>MCP: JSONRPCMessage
+```
+
+A simple convention such as **one complete UTF-8 JSON-RPC message per WebSocket text frame** is enough for framing.
+
+There is substantial SDK precedent. The Kotlin SDK currently advertises WebSocket transport support alongside stdio, SSE, and Streamable HTTP. The Python SDK has an official WebSocket client adapter that produces the same typed `SessionMessage` streams consumed by `ClientSession`. TypeScript v1 formerly included `WebSocketClientTransport`; v2 deliberately removed it because WebSocket is not a standard MCP transport, while retaining the public `Transport` interface for users to implement custom transports themselves.
+
+That TypeScript v2 decision is actually a strong argument **for** pluggability: the SDK maintainers did not want every useful carrier in core, but they explicitly retained the seam needed to supply one externally.
+
+### SSH
+
+SEP-2325 is a textbook example of JSON-RPC-preserving transport composition.
+
+Its simplest deployment is:
+
+```text
+MCP SDK
+   │
+   │ newline-delimited JSON-RPC
+   ▼
+SSH channel / subsystem
+   │
+   ▼
+remote process stdin/stdout
+   │
+   ▼
+existing MCP stdio server
+```
+
+The proposal's key observation was that **any stdio MCP server can immediately function behind an SSH subsystem**, because SSH supplies secure remote byte streams while MCP continues to use its normal stdio-compatible framing. It also explored an embedded SSH server for applications needing shared state or persistent server infrastructure.
+
+The SEP additionally referenced a stdio-to-SSH shim, which is precisely what a pluggable ecosystem should permit: old clients see stdio, while the adapter substitutes SSH underneath. The proposal was ultimately closed due to inactivity, with the author saying the code remained useful and could be revived if interest returned.
+
+Under a JSON-RPC `Transport` contract, SSH requires **zero changes to MCP method semantics**.
+
+### gRPC tunnel versus native gRPC
+
+There are two fundamentally different gRPC architectures.
+
+A **JSON-RPC tunnel** can look like:
+
+```proto
+message JsonRpcFrame {
+  bytes json = 1;
+}
+
+service McpTransport {
+  rpc Session(stream JsonRpcFrame)
+      returns (stream JsonRpcFrame);
+}
+```
+
+The SDK side remains:
+
+```text
+JSONRPCMessage
+      │
+      ▼
+serialize JSON
+      │
+      ▼
+gRPC frame
+      │
+      ▼
+HTTP/2 / HTTP/3 networking
+```
+
+This fits the proposed `Transport` abstraction. gRPC can supply TLS/mTLS, load balancing, service discovery, observability, multiplexing, and enterprise routing while MCP still owns JSON-RPC IDs, method names, parameters, results, errors, and notifications.
+
+Daniel Smith's `mcp-grpc-transport`, referenced directly in SEP-2598, provides useful real-world precedent. It implements a native protobuf MCP service **and an optional bidirectional JSON-RPC fallback stream** intended for proxying. The fallback stream is the transport design discussed here; the native protobuf service is a separate binding design.
+
+A **native gRPC binding**, by contrast, could expose operations such as:
+
+```text
+rpc CallTool(CallToolRequestParams) returns (CallToolResult)
+rpc ListTools(ListToolsRequestParams) returns (ListToolsResult)
+```
+
+That eliminates the JSON-RPC wrapper. It is precisely where SEP-2598's reviewers encountered request-ID, cancellation, initialization, and feature-mapping problems. SEP-1319 is the appropriate architectural foundation for that work because it defines the payloads independently of the JSON-RPC method wrapper.
+
+Therefore:
+
+**gRPC carrying opaque/serialized MCP JSON-RPC = Transport.**
+**gRPC replacing JSON-RPC methods with protobuf RPC methods = native MCP/gRPC binding.**
+
+Trying to standardize both under one `Transport` interface is what made SEP-2598 difficult.
+
+### Cap'n Web and Cloudflare RPC
+
+Cap'n Web presents the same distinction more sharply because it is itself a JavaScript-native object-capability RPC system.
+
+Its public `RpcTransport` abstraction is strikingly simple:
+
+```ts
+interface RpcTransport {
+    send(message: string): Promise<void>;
+    receive(): Promise<string>;
+    abort?(reason: unknown): void;
+}
+```
+
+Cloudflare explicitly documents it as the interface for implementing Cap'n Web over arbitrary bidirectional streams.
+
+An MCP tunnel could therefore be layered conceptually as:
+
+```text
+MCP JSONRPCMessage
+       │
+       ▼
+CapnWebMcpTransport
+       │
+       │ "send this complete MCP message"
+       ▼
+Cap'n Web / Cloudflare RPC
+       │
+       ▼
+remote adapter
+       │
+       ▼
+MCP JSONRPCMessage
+```
+
+Or, in object-RPC pseudocode:
+
+```ts
+await remote.handleMcpMessage(jsonRpcMessage);
+```
+
+The Cloudflare Agents `RPCServerTransport` provides evidence that this general shape exists in production-oriented code. Issue #1540 describes overlapping `handleMcpMessage()` calls and a single `_pendingResponse` / `_responseResolver` pair being overwritten, resulting in a successful upstream MCP call whose JSON-RPC response never reaches the waiting caller. The issue was assigned to Matt Carey.
+
+That is an important design lesson: do **not** assume an RPC carrier's native call correlation automatically solves MCP transport correlation when an adapter multiplexes multiple MCP messages. The conformance suite must exercise concurrent traffic.
+
+On the other hand, an API like:
+
+```ts
+remote.tools.call(name, args)
+remote.resources.read(uri)
+```
+
+with Cap'n Web promises/capabilities flowing natively is no longer merely carrying MCP JSON-RPC. That is a **native Cap'n Web binding** and should be built on transport-agnostic MCP payload definitions such as those established by SEP-1319.
+
+### Streamable HTTP variants show what should stay out of the generic interface
+
+The existing Streamable HTTP implementations demonstrate why a generic `Transport` should remain narrow.
+
+TypeScript's generic send options have accumulated request association, request-stream termination, headers, cancellation and resumption concepts. Python's Streamable HTTP implementation attaches rich request context and stream-control metadata to received messages. Swift provides a dedicated `StatelessHTTPServerTransport` with no MCP session ID, direct JSON responses, and no GET/DELETE streaming semantics. Ruby's transport supports stateful/stateless operation, optional single-JSON response mode, per-request SSE streams, session SSE streams, request-to-stream association, and session lifecycle controls.
+
+All of those are reasonable **Streamable HTTP implementation details**.
+
+They should not become requirements of:
+
+```text
+Transport<JSONRPCMessage>
+```
+
+A generic extension point should not require:
+
+```text
+HTTP headers
+HTTP status codes
+POST/GET/DELETE
+SSE event IDs
+Last-Event-ID
+Mcp-Session-Id
+response streams
+Origin/Host HTTP policy
+```
+
+Instead, where a carrier genuinely needs context to route an outgoing response back through the correct ingress operation, the SDK should allow an **opaque transport context**.
+
+A language-neutral semantic model would be:
+
+```text
+ReceivedMessage {
+    message: JSONRPCMessage
+    context?: opaque TransportContext
+}
+
+Transport:
+    start/connect
+    send(message, optional context)
+    receive -> message + optional context
+    close
+```
+
+For Streamable HTTP, the opaque context might identify the incoming POST or response stream. For `postMessage`, it might identify a `Window` or `MessagePort`. For QUIC it might be a stream handle. For stdio/WebSocket it will often be absent.
+
+The protocol layer must not inspect it.
+
+### In-process transports are especially valuable
+
+The existing in-process implementations prove that "transport" need not mean "network protocol."
+
+Go's `NewInMemoryTransports()` creates connected transport endpoints around the same `jsonrpc.Message` boundary. Kotlin's `ChannelTransport` sends and receives `JSONRPCMessage` over coroutine channels and explicitly documents a linked pair for client/server communication without external networking. TypeScript exports `InMemoryTransport`, and its examples use linked in-memory pairs to exercise real client/server protocol paths. Python's entire transport architecture already adapts actual network/process I/O into AnyIO memory-object streams before the session layer sees it.
+
+These should form the baseline implementation of a conformance harness because they isolate **transport API semantics** from networking behavior.
+
+## Recommended first implementation, conformance plan, and migration
+
+The best first step is no longer to *invent* `PostMessageTransport`; it is to **promote the existing MCP Apps implementation from a domain-specific example into the reference demonstration of the generic SDK extension point**.
+
+### Proposed contract
+
+A replacement or successor to SEP-2598 should deliberately stop short of requiring identical APIs in every SDK.
+
+A suitable normative statement would be:
+
+> An MCP SDK transport extension point accepts and emits complete MCP JSON-RPC messages and is responsible for carrying those messages through an implementation-defined communication mechanism. The extension point must not require carrier-specific concepts from stdio or Streamable HTTP. SDKs may express this contract using interfaces, traits, protocols, streams, channels, callbacks, or other idiomatic language constructs.
+
+This fits the current specification's rule that custom transports preserve JSON-RPC and MCP message patterns.
+
+A second requirement should separate the native-binding problem:
+
+> A mechanism that replaces MCP's JSON-RPC method layer with another RPC system's native method or capability model is a separate protocol binding and is not required to implement the JSON-RPC transport extension contract.
+
+That makes SEP-1319, rather than the Transport interface, the foundation for future native gRPC or native Cap'n Web work.
+
+### PostMessage prototype
+
+Use [`ext-apps/src/message-transport.ts`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/message-transport.ts) as prototype zero rather than creating a competing implementation.
+
+Generalize it in three ways:
+
+```ts
+class PostMessageTransport implements Transport {
+  constructor({
+    sendTarget,
+    receiveTarget,
+    expectedSource,
+    targetOrigin,
+  }: Options) {}
+
+  start(): Promise<void>;
+  send(message: JSONRPCMessage): Promise<void>;
+  close(): Promise<void>;
+}
+```
+
+First, support a defined origin policy rather than assuming `"*"`. Second, make the receive event target injectable so the same design can cover `Window`, workers, and appropriate `MessagePort` adapters. Third, keep the public API strictly in terms of `JSONRPCMessage`; no HTTP/session/resumption fields should appear unless an optional, generic context/capability extension genuinely requires them.
+
+A subsequent implementation can be a tiny `WebSocketTransport`, because it exercises actual serialization/framing while retaining almost identical MCP semantics.
+
+### Conformance checklist
+
+Rather than require every Tier-1 SDK maintainer to create a separate language-specific harness—the burden objection raised during SEP-2598—a shared scenario specification should define transport behavior, with SDKs free to implement those scenarios idiomatically.
+
+| Area | Required test |
+|---|---|
+| Message fidelity | A valid request, response, notification, error, IDs, `_meta`, and unknown extension fields arrive unchanged at the MCP layer. |
+| Request/response | A simple request passes through the custom transport and receives the correct JSON-RPC response. |
+| Concurrency | Multiple overlapping requests resolve to their correct responses even when responses arrive out of order. This directly targets the failure observed in Cloudflare's RPC transport. |
+| Bidirectional/legacy compatibility | For protocol revisions that support server-initiated requests, those messages work when the transport advertises/supports them; modern 2026-07-28 behavior follows the newer message-direction rules. |
+| Notifications | Supported notifications are delivered without accidentally waiting for responses. |
+| Cancellation | The carrier's cancellation mechanism correctly realizes MCP cancellation rules and does not strand underlying request resources. |
+| Lifecycle | Start/connect and close/disconnect are deterministic; close unblocks pending receives and is safe to invoke repeatedly where the SDK contract expects it. |
+| Malformed input | Non-MCP data can be ignored when appropriate; malformed values claiming to be JSON-RPC produce a controlled error rather than crashing the transport. MCP Apps already distinguishes these cases. |
+| Backpressure | A slow receiver cannot silently overwrite earlier messages; queues have a documented behavior. |
+| Failure propagation | Carrier disconnect/failure wakes outstanding operations with a deterministic transport error. |
+| Carrier context | Any opaque response-routing context is returned unchanged to its own transport; protocol code cannot inspect carrier-specific contents. |
+| HTTP independence | The reference custom transport functions without session IDs, HTTP headers, SSE IDs, HTTP status codes, or request methods. |
+| Security | Carrier-specific authentication/source checks are exercised; PostMessage tests verify expected source/origin, SSH tests verify host/key policy, network transports follow their own security profile. |
+| Protocol-version behavior | If the SDK exposes transport protocol-version support, unsupported versions fail predictably and supported versions are forwarded correctly. |
+| Extension fields | Unknown `_meta` and extension data survives the carrier, avoiding a transport that accidentally reserializes only known schema fields. |
+
+The **Cloudflare RPC concurrency bug should be made a mandatory test case**, not merely a regression test for Cloudflare. It is exactly the type of failure a pluggable-transport specification should prevent.
+
+### Migration notes by SDK family
+
+**TypeScript, Kotlin, Java, C#, Go, and Rust require no new architectural layer.** Their existing interfaces should be declared conforming extension points and given the common behavioral documentation. TypeScript and Kotlin may gradually separate carrier-neutral send/context options from HTTP-specific options.
+
+For **Go**, do not make removal of `SessionID()` a prerequisite for the first transport proposal. The existing TODO can be handled on the SDK's normal compatibility schedule.
+
+For **Python**, leave every existing `ClientSession(read_stream, write_stream)` API working. Introduce a typing `Protocol` or documented async transport factory as a convenience around the established stream-pair ABI:
+
+```python
+class Transport(Protocol):
+    async def open(self) -> AsyncContextManager[
+        tuple[ReadStream[SessionMessage | Exception],
+              WriteStream[SessionMessage]]
+    ]: ...
+```
+
+The exact syntax is less important than documenting that producing these streams constitutes a valid custom transport. The existing WebSocket adapter proves the model.
+
+For **Swift**, preserve today's `Data`-oriented `Transport`. Add a reusable `JSONRPCTransportAdapter` that performs MCP decoding/encoding around any `Transport`. That keeps `NetworkTransport`, stdio, and HTTP binary-I/O implementations compatible while giving third-party transport authors a typed MCP-level extension point.
+
+For **PHP**, do not retrofit the existing `TransportInterface` in place because it currently includes execution and carrier context such as HTTP status codes. Add something closer to:
+
+```php
+interface MessageTransportInterface
+{
+    public function send(JsonRpcMessage $message, mixed $context = null): void;
+    public function onMessage(callable $listener): void;
+    public function close(): void;
+}
+```
+
+Then adapt `TransportInterface` implementations to it. PR #160's Protocol/Transport decoupling makes that evolution significantly easier.
+
+For **Ruby**, introduce a lightweight message-level base/duck-type and have stdio and Streamable HTTP adapt into it; leave Rack-facing `call(env)` and session management in the HTTP adapter. `MCP::Server#handle` already accepts parsed JSON-RPC independently enough to make this achievable without rewriting the entire protocol engine.
+
+### Suggested implementation sequence
+
+The order should be deliberately conservative:
+
+```mermaid
+flowchart LR
+    A[Document semantic Transport contract]
+    B[Use ext-apps PostMessageTransport as prototype zero]
+    C[Add concurrency / lifecycle / fidelity conformance scenarios]
+    D[Extract or publish reusable PostMessage adapter]
+    E[Implement WebSocket reference adapter]
+    F[Implement RPC JSON-RPC tunnel]
+    G[Evaluate native RPC bindings separately]
+
+    A --> B --> C --> D --> E --> F --> G
+```
+
+The first deliverable changes **no MCP wire protocol**.
+
+The second proves an already-running non-standard carrier.
+
+The third catches correlation and lifecycle errors.
+
+Only after that should an RPC-framework tunnel be used to demonstrate that the abstraction works beyond byte-stream transports.
+
+Native gRPC and native Cap'n Web should remain explicitly out of scope for this first step.
+
+## Gaps, high-value searches, and authors to contact
+
+Several examples remain either missing or only indirectly observable in indexed primary sources.
+
+Most importantly, I did **not** verify the specific public Matt Carey branches/forks named `rpctransport` or `capnwebtransport`. What is verified is a Cloudflare Agents `RPCServerTransport` used by `McpAgent`, with a concurrency issue assigned to Matt Carey, and Cloudflare Cap'n Web's independent generic `RpcTransport`. A direct `CapnWebTransport implements Transport` source artifact remains missing.
+
+Likewise, SEP-2325's PR page verifies that the author supplied a Go SDK branch, example SSH server, and shim, but the individual URLs were not exposed reliably by the indexed page returned during this research. The PR itself remains the authoritative entry point to those references.
+
+No clearly reusable **first-class in-process transport** was located in the Java, C#, PHP, Ruby, or Swift SDKs during this pass. That does not prove none exists—test fixtures are often poorly indexed—but Go, Kotlin, and TypeScript provide verified examples, while Python's stream architecture makes an in-memory pair straightforward by construction.
+
+The following GitHub code-search queries are the highest-value next searches:
+
+```text
+org:modelcontextprotocol
+("implements Transport" OR ": Transport" OR "TransportInterface")
+JSONRPCMessage
+-stdio -streamable
+```
+
+```text
+repo:modelcontextprotocol/typescript-sdk
+("implements Transport" OR "TransportSendOptions")
+(WebSocket OR postMessage OR MessagePort OR RPC)
+```
+
+```text
+fork:true
+("PostMessageTransport" OR "MessagePortTransport")
+"@modelcontextprotocol"
+```
+
+```text
+fork:true
+("CapnWebTransport" OR "capnwebtransport" OR "RpcTransport")
+(MCP OR modelcontextprotocol)
+```
+
+```text
+user:mattzcarey
+(rpctransport OR capnwebtransport OR RPCServerTransport OR handleMcpMessage)
+```
+
+```text
+org:cloudflare
+("RPCServerTransport" OR "handleMcpMessage" OR "McpAgent")
+```
+
+```text
+"mcp-grpc-transport"
+("JSON-RPC" OR "bidirectional" OR "Session")
+```
+
+```text
+("ssh-mcp-shim" OR "SSHClientTransport" OR "SSHServerTransport")
+MCP
+```
+
+```text
+org:modelcontextprotocol
+("InMemoryTransport" OR "ChannelTransport" OR
+ "MemoryObjectReceiveStream" OR "in-memory transport")
+```
+
+```text
+org:modelcontextprotocol
+("WebSocketClientTransport" OR "WebSocketServerTransport")
+```
+
+The most relevant people to contact are also fairly clear from the primary-source record.
+
+| Person | Why they are particularly relevant |
+|---|---|
+| **Kurtis Van Gent (`@kurtisvg`)** | Author of SEP-2598, gRPC issue #966, and SEP-1319 on behalf of the Transport WG; best source for intended boundary between custom transports and native bindings. |
+| **Mark Roth (`@markdroth`)** | Raised the most substantive SEP-2598 objections around request IDs, `initialize`, cancellation, and native gRPC semantics; critical reviewer for keeping Transport separate from native binding. |
+| **`@pcarleton`** | Raised the cross-SDK conformance-maintenance concern and suggested optional centralized extension conformance instead. |
+| **`@halter73`** | Argued against over-prescribing identical SDK interface forms and discussed the Python-side response/request association issue. |
+| **Larry Maccherone (`@lmaccherone`)** | Author of SEP-1288 WebSocket transport; useful for framing and WebSocket extension history. |
+| **`@tobert`** | Author and prototype implementer of SEP-2325 SSH, including Go branch, example server, and shim work. |
+| **Matt Carey (`@mattzcarey`)** | Cloudflare Agents RPC transport issue #1540 is assigned to him; most likely person to confirm the requested `rpctransport` / `capnwebtransport` history and whether those were private, transient, renamed, or unindexed branches. |
+| **Daniel Smith (`@danielsmithdevelopment` / `@danielsmithdev`)** | Maintains the cited `mcp-grpc-transport`, including the particularly relevant bidirectional JSON-RPC fallback stream. |
+| **Christian Tzolov and Dariusz Jędrzejczyk** | Named authors on Java's `McpTransport`; useful for confirming that the current Java abstraction should be treated as the official custom-transport seam. |
+| **Christopher Hertel and Kyrian Obikwelu** | Named authors on PHP's `TransportInterface`; useful for evaluating a second, narrower message-level interface. |
+| **`@lvluoyue`** | Author of PHP PR #160 decoupling `Protocol` from `TransportInterface`, directly relevant to a staged PHP migration. |
+
+The overall evidence supports a fairly strong design recommendation: **do not revive SEP-2598 unchanged. Narrow it to the extension point that the SDKs and current specification already mostly have.**
+
+The target should be a **message transport boundary at `JSONRPCMessage` / equivalent**, expressed idiomatically per language, with optional opaque carrier context where response routing demands it. The existing PostMessage, WebSocket, SSH, TCP/UDP, channel, and in-memory examples demonstrate that this is not speculative.
+
+A gRPC or Cloudflare/Cap'n-Web-style RPC framework can then be substituted underneath in one of two clearly named modes:
+
+**JSON-RPC tunnel:** fits `Transport`, preserves MCP JSON-RPC, requires little or no MCP-core change.
+
+**Native RPC binding:** replaces the JSON-RPC method layer and should be designed separately using SEP-1319's transport-agnostic payload definitions.
+
+That separation preserves the valuable goal of SEP-2598 while avoiding precisely the semantic and SDK-governance issues that caused it to stall.

--- a/docs/pluggable/streamable-http-wire-diagrams.md
+++ b/docs/pluggable/streamable-http-wire-diagrams.md
@@ -1,0 +1,324 @@
+# Streamable HTTP wire diagrams — where the transport seam sits
+
+Per-SDK diagrams of how an MCP client and server connect in code over the **Streamable HTTP** wire, with the **transport extension point** marked: the exact spot where a different carrier (WebSocket, `postMessage`, in-memory, Unix socket, …) can be substituted without touching MCP protocol logic.
+
+All names and file paths are source-verified against each SDK's `main` branch (2026-08). Version notes per SDK below.
+
+## Reading the diagrams
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Client"]
+    APP["App code"] --> PROTO["Client protocol engine<br/>(JSON-RPC dispatch · correlation)"]
+    PROTO --> SEAM1["Transport extension point"]
+    SEAM1 --> IMPL1["Streamable HTTP client transport"]
+  end
+  IMPL1 --> WIRE["Wire: Streamable HTTP<br/>POST JSON-RPC · GET SSE · DELETE"]
+  WIRE --> IMPL2["Streamable HTTP server transport"]
+  subgraph SERVER["Server"]
+    IMPL2 --> SEAM2["Transport extension point"]
+    SEAM2 --> DSP["Server protocol engine / dispatcher"]
+    DSP --> H["Tool · resource · prompt handlers"]
+  end
+  ALT["Alternative transport<br/>WebSocket · postMessage · in-memory · Unix socket"]
+  SEAM1 -.-> ALT
+  ALT -.-> SEAM2
+```
+
+- Solid arrows = actual call/data flow in code.
+- Amber nodes = the transport seam (interface, protocol, trait, duck type, or stream pair). Swapping the concrete transport implementation here substitutes a different carrier.
+- Dashed arrows = substitution: an alternative transport implements the same seam and is injected at the same call site.
+
+## Summary
+
+| SDK | Client seam | Client injection | Server seam | Server injection | Shipped custom-transport precedents |
+| --- | --- | --- | --- | --- | --- |
+| TypeScript | `Transport` interface | `client.connect(transport)` | same `Transport` interface | `server.connect(transport)` (v1) / `PerRequestHTTPServerTransport` in `createMcpHandler` (v2) | `PostMessageTransport` (ext-apps), `InMemoryTransport` |
+| Python | `Transport` protocol → `(read_stream, write_stream)` | `Client(server=transport)` / `ClientSession(read_stream, write_stream)` | stream pair consumed by `JSONRPCDispatcher` / `serve_loop` | `serve_loop(server, streams)`; modern per-request handler | WebSocket (removed in v2), in-process direct dispatcher pair |
+| Java | `McpClientTransport` | `McpClient.sync/async(transport)` | `McpStreamableServerTransportProvider` | `McpServer.sync/async(provider)` | `StdioClientTransport`, `McpStatelessServerTransport`, legacy SSE |
+| Kotlin | `Transport` interface | `Client.connect(transport)` | same `Transport` interface | `Server.createSession(transport)` | `WebSocketClientTransport`, `ChannelTransport`, `InMemoryTransport` |
+| C# | `IClientTransport` | `McpClient.CreateAsync(transport)` | `ITransport` | `McpServer.Create(transport, …)` (ASP.NET handler constructs HTTP transport directly) | `StreamClientTransport`/`StreamServerTransport`, `StdioClientTransport` |
+| Go | `mcp.Transport` | `client.Connect(ctx, transport)` | same `mcp.Transport` | `server.Connect(ctx, transport)` | `InMemoryTransport`, `StdioTransport`, custom-transport example |
+| PHP | client `TransportInterface` | `Client::connect($transport)` | server `TransportInterface` | `Server::run($transport)` | `InMemoryTransport`, `StdioTransport` |
+| Ruby | duck type `send_request(request:)` | `MCP::Client.new(transport:)` | `MCP::Transport` base (coupled) | transport ctor `super(server)` → `server.transport = self` | documented `CustomTransport` duck type (client) |
+| Rust (rmcp) | `Transport` trait / `IntoTransport` | `client_info.serve(transport)` | same `Transport` trait | `serve_server(service, transport)`; `OneshotTransport` for stateless HTTP | `SinkStreamTransport`, `AsyncRwTransport`, in-process `WorkerTransport`, `UnixSocketHttpClient` |
+| Swift | `Transport` protocol (byte-level) | `Client.connect(transport:)` | same `Transport` protocol | `Server.start(transport:)` | `NetworkTransport` (Apple Network), `InMemoryTransport`, documented `MyCustomTransport` |
+
+---
+
+## TypeScript
+
+- **Version:** v2 packages @ 2.0.0, main @ 3924de99 (2026-08-18). Two coexisting serving paths: v2 `createMcpHandler` (per-request transport, blessed) and v1 `WebStandardStreamableHTTPServerTransport` (connection-oriented, still exported).
+- **Wire:** single endpoint URL. POST carries every JSON-RPC message (`Content-Type: application/json`, `Accept: application/json, text/event-stream`, legacy `Mcp-Session-Id`, `MCP-Protocol-Version`, SEP-2243 body-derived `mcp-protocol-version`/`mcp-method`/`mcp-name`). Responses: 200 SSE (`event: message` / `data: <JSON>` frames, optional `id:`/`retry:`) or 200 `application/json`; 202 for notification-only POSTs. Legacy era: standalone GET SSE stream + DELETE session termination. Modern era (2026-07-28): POST-only, stateless, no session header.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["TypeScript client"]
+    A["App: new Client({ name, version })<br/>packages/client/src/client/client.ts:632"] --> B["client.connect(transport)<br/>client.ts:982"]
+    B --> C["Protocol.connect(transport)<br/>packages/core-internal/src/shared/protocol.ts:785"]
+    C --> D["StreamableHTTPClientTransport(url)<br/>packages/client/src/client/streamableHttp.ts:343"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE (legacy) · DELETE (legacy)"]
+  W --> E["createMcpHandler(factory) → handler.fetch(request)<br/>packages/server/src/server/createMcpHandler.ts:622"]
+  subgraph SERVER["TypeScript server"]
+    E --> F["PerRequestHTTPServerTransport<br/>packages/server/src/server/perRequestTransport.ts:122"]
+    F --> G["server.connect(transport)<br/>→ Protocol.connect · protocol.ts:785"]
+    G --> H["McpServer handlers<br/>tools · prompts · resources"]
+  end
+  ALT["Alternative carrier:<br/>PostMessageTransport (ext-apps)<br/>InMemoryTransport"]
+  C -.-> ALT
+  ALT -.-> F
+```
+
+- **Seam:** `Transport` interface — `start()`, `send(message, options?)`, `close()`, callbacks `onclose`/`onerror`/`onmessage` — at `packages/core-internal/src/shared/transport.ts:107`. Injected at `Protocol.connect(transport)` (protocol.ts:785) from both `Client.connect` and `McpServer.connect`; v2's per-request path constructs `PerRequestHTTPServerTransport` and calls the same `server.connect(transport)` (invoke.ts:61-66). Proof the seam works: `PostMessageTransport` (modelcontextprotocol/ext-apps, src/message-transport.ts:46) implements this exact interface over `window.postMessage` with no HTTP anywhere.
+
+---
+
+## Python
+
+- **Version:** mcp v2, main @ 57394b0 (2026-08-20). Client field is named `server=` — a custom `Transport` instance goes in `Client(server=…)`; a URL string selects Streamable HTTP. Server is Starlette/ASGI + uvicorn only.
+- **Wire:** single endpoint (default `/mcp`). Client POSTs one JSON-RPC message (`Content-Type: application/json`, `Accept: application/json, text/event-stream`, `mcp-session-id` legacy, `mcp-protocol-version`, per-message `mcp-method`/`mcp-name`/`Mcp-Param-*`). Response `application/json`, or SSE `event: message` / `data: <JSON>` frames. Legacy: GET standalone SSE + `Last-Event-ID` replay + DELETE. Modern (2026-07-28): stateless POST-only, 405 otherwise, response-stream close = cancellation.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Python client"]
+    A["App: async with Client(url)<br/>or Client(server=my_transport)<br/>src/mcp/client/client.py:261"] --> B["_connect_transport(...)<br/>enter_async_context(transport)<br/>client.py:93-100"]
+    B --> C["Transport protocol (seam)<br/>→ (read_stream, write_stream)<br/>src/mcp/client/_transport.py:13"]
+    C --> D["streamable_http_client(url)<br/>StreamableHTTPTransport + httpx2<br/>src/mcp/client/streamable_http.py:639"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE (legacy) · DELETE (legacy)"]
+  W --> E["StreamableHTTPASGIApp → session manager<br/>src/mcp/server/streamable_http_manager.py:371"]
+  subgraph SERVER["Python server"]
+    E --> F["StreamableHTTPServerTransport<br/>src/mcp/server/streamable_http.py:149"]
+    F --> G["JSONRPCDispatcher(read_stream, write_stream)<br/>serve_loop(server, streams) · runner.py:470"]
+    G --> H["ServerRunner → handlers<br/>tools · resources · prompts"]
+  end
+  ALT["Alternative carrier:<br/>any async-CM producing SessionMessage streams<br/>(WebSocket precedent shipped in v1, removed in v2)"]
+  C -.-> ALT
+  ALT -.-> G
+```
+
+- **Seam:** client = `Transport` protocol (`src/mcp/client/_transport.py:13`): async context manager yielding `TransportStreams = (ReadStream, WriteStream)` of `SessionMessage`, handed to `JSONRPCDispatcher` (client.py:97-98). Server = no public `Transport` protocol, but `serve_loop(server, read_stream, write_stream, …)` (runner.py:470) accepts any read/write stream pair — `StreamableHTTPServerTransport.connect()` is just the HTTP realization of that pair. Substituting a carrier = implementing the async-CM stream pair (or, on the server, any stream pair feeding the dispatcher).
+
+---
+
+## Java
+
+- **Version:** java-sdk main, pom 2.1.0-SNAPSHOT (post-2.0 session refactor); reactive (Project Reactor). Streamable HTTP is session-oriented: POST per message, GET SSE listening stream, DELETE termination, `Last-Event-ID` resumption.
+- **Wire:** single URL, default `/mcp`. POST with `Accept: application/json, text/event-stream`, `Content-Type: application/json; charset=utf-8`, `Mcp-Session-Id` (after initialize), `MCP-Protocol-Version`. Initialize → 200 JSON + `Mcp-Session-Id` response header; responses/notifications → 202; requests → 200 SSE (`event: message` / `data: <JSON>`). GET → SSE listening stream; DELETE → session termination.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Java client"]
+    A["App: McpClient.sync(transport)<br/>or McpClient.async(transport)<br/>client/McpClient.java:126,143"] --> B["McpClientTransport (seam)<br/>spec/McpClientTransport.java:20"]
+    B --> C["McpAsyncClient → LifecycleInitializer<br/>→ McpClientSession<br/>transport.connect(handler) · sendMessage(...)"]
+    C --> D["HttpClientStreamableHttpTransport<br/>client/transport/HttpClientStreamableHttpTransport.java:84"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE stream · DELETE"]
+  W --> E["HttpServletStreamableServerTransportProvider<br/>doPost / doGet / doDelete<br/>(or Spring AI WebMvc/WebFlux provider)"]
+  subgraph SERVER["Java server"]
+    E --> F["McpStreamableServerTransportProvider (seam)<br/>spec/McpStreamableServerTransportProvider.java:36"]
+    F --> G["McpAsyncServer → setSessionFactory<br/>→ McpStreamableServerSession"]
+    G --> H["requestHandlers<br/>tools · resources · prompts"]
+  end
+  ALT["Alternative carrier:<br/>implement McpClientTransport /<br/>McpStreamableServerTransportProvider<br/>(StdioClientTransport precedent)"]
+  B -.-> ALT
+  ALT -.-> F
+```
+
+- **Seam:** client = `McpClientTransport` (`spec/McpClientTransport.java:20`, extends `McpTransport` with `connect(handler)`, `sendMessage`, `unmarshalFrom`, `protocolVersions`) — injected at `McpClient.sync/async(transport)`. Server = `McpStreamableServerTransportProvider` (`spec/McpStreamableServerTransportProvider.java:36`) — injected at `McpServer.sync/async(provider)`; `McpAsyncServer` installs `DefaultMcpStreamableServerSessionFactory` on it (McpAsyncServer.java:186-188) to create per-client session/transport pairs. `HttpClientStreamableHttpTransport`/`HttpServletStreamableServerTransportProvider` are just two implementations. Migration guide documents custom implementors (`MIGRATION-2.0.md`).
+
+---
+
+## Kotlin
+
+- **Version:** kotlin-sdk main @ 815a70e (2026-08-20); multiplatform, Ktor 3.5.2. Server DSLs default to `enableJsonResponse = true` (JSON mode); stateful SSE needs `StreamableHttpServerTransport(Configuration(enableJsonResponse = false))`.
+- **Wire:** single endpoint (default `/mcp`). POST with `Content-Type: application/json`, `Accept: application/json, text/event-stream`, `mcp-session-id`, `mcp-protocol-version`, `Mcp-Method`, `Mcp-Name`. Responses: SSE (`event: message`, `id:`, `retry:`, `data: <JSON>`) or JSON (single object or batch array); 202 for notifications. GET standalone SSE + `Last-Event-ID`; DELETE termination.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Kotlin client"]
+    A["App: HttpClient.mcpStreamableHttpTransport(url)<br/>client/StreamableHttpMcpKtorClientExtensions.kt:19"] --> B["Client.connect(transport)<br/>client/Client.kt:202"]
+    B --> C["Transport interface (seam)<br/>shared/Transport.kt:8<br/>start/send/close/onMessage"]
+    C --> D["StreamableHttpClientTransport<br/>Ktor POST + GET SSE loop"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE · DELETE"]
+  W --> E["Application.mcpStreamableHttp(path = '/mcp')<br/>server/KtorServer.kt:240"]
+  subgraph SERVER["Kotlin server"]
+    E --> F["StreamableHttpServerTransport<br/>Ktor routes sse / post / delete"]
+    F --> G["Server.createSession(transport)<br/>server/Server.kt:216 → Protocol.connect"]
+    G --> H["ServerSession handlers<br/>initialize · ping · tools"]
+  end
+  ALT["Alternative carrier:<br/>WebSocketClientTransport<br/>ChannelTransport · InMemoryTransport"]
+  C -.-> ALT
+  ALT -.-> G
+```
+
+- **Seam:** `Transport` interface (`shared/Transport.kt:8`): `start()`, `send(message, options?)`, `close()`, `onClose/onError/onMessage`. Client and server both funnel through `Protocol.connect(transport)` (Protocol.kt:369-430) — client via `Client.connect(transport)` (Client.kt:202), server via `Server.createSession(transport)` (Server.kt:216) → `ServerSession.connect(transport)`. Kotlin already ships the proof: `WebSocketClientTransport`/`WebSocketMcpServerTransport`, `ChannelTransport` (coroutine channels), `InMemoryTransport`.
+
+---
+
+## C #
+
+- **Version:** csharp-sdk main @ 609499b (2026-08-19). No `McpClientFactory` — the seam is the static `McpClient.CreateAsync(IClientTransport, …)`. Client default `HttpTransportMode.AutoDetect` (Streamable HTTP first, SSE fallback). v2 (2026-07-28 stateless) is default; stateful pieces carry `[Obsolete]` markers.
+- **Wire:** endpoint from `HttpClientTransportOptions.Endpoint`. POST with `Accept: application/json, text/event-stream`, `MCP-Protocol-Version`, `Mcp-Session-Id` (stateful), `Last-Event-ID`, `Mcp-Method`, `Mcp-Name`, `Mcp-Param-*`. Response JSON or SSE (`data:` per message); 202 for notifications. Stateful: GET SSE for unsolicited messages; DELETE termination.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["C# client"]
+    A["App: new HttpClientTransport(options)<br/>samples/QuickstartClient/Program.cs:22"] --> B["McpClient.CreateAsync(clientTransport)<br/>Client/McpClient.Methods.cs:40"]
+    B --> C["IClientTransport (seam)<br/>Client/IClientTransport.cs:18<br/>ConnectAsync() → ITransport"]
+    C --> D["StreamableHttpClientSessionTransport<br/>POST via McpHttpClient + GET SSE"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE (stateful) · DELETE (stateful)"]
+  W --> E["MapMcp() → StreamableHttpHandler<br/>AspNetCore/StreamableHttpHandler.cs:64"]
+  subgraph SERVER["C# server"]
+    E --> F["StreamableHttpServerTransport<br/>constructed directly — no provider seam"]
+    F --> G["McpServer.Create(ITransport, …) (seam)<br/>Server/McpServer.Methods.cs:58"]
+    G --> H["McpServerImpl → McpSessionHandler<br/>→ requestHandlers"]
+  end
+  ALT["Alternative carrier:<br/>implement IClientTransport / ITransport<br/>(StreamClientTransport precedent)"]
+  C -.-> ALT
+  ALT -.-> G
+```
+
+- **Seam:** client = `IClientTransport` (`Client/IClientTransport.cs:18`: `Name`, `ConnectAsync() → ITransport`) injected at `McpClient.CreateAsync`. Server = `ITransport` (`Protocol/ITransport.cs:26`: `SessionId`, channel-backed `MessageReader`, `SendMessageAsync`) injected at `McpServer.Create(ITransport, …)`. Note the asymmetry: the ASP.NET integration (`WithHttpTransport`/`StreamableHttpHandler`) constructs `StreamableHttpServerTransport` directly with no provider abstraction — the generic server seam is `McpServer.Create` itself. `StreamClientTransport`/`StreamServerTransport` already make arbitrary .NET `Stream` pairs work as a carrier.
+
+---
+
+## Go
+
+- **Version:** go-sdk main @ 3d6450f (2026-08). No `NewStreamableHTTPClient`/`NewStreamableHTTPServer` — the client transport is the struct `StreamableClientTransport`, the server is the `http.Handler` `StreamableHTTPHandler`.
+- **Wire:** single URL. POST every JSON-RPC message (`Content-Type: application/json`, `Accept: application/json, text/event-stream`, `Mcp-Protocol-Version`, `Mcp-Session-Id` when stateful, SEP-2575 `Mcp-Method`/`Mcp-Name`/`Mcp-Param-*`). Responses: 202 (notifications), 200 JSON, or 200 SSE (`event: message`, `id: <streamID>_<idx>`, `data: <JSON>`). GET standalone SSE + `Last-Event-ID`; DELETE termination. Stateless mode: POST only, 405 otherwise.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Go client"]
+    A["App: mcp.NewClient(impl)<br/>mcp/client.go:51"] --> B["client.Connect(ctx, transport, nil)<br/>client.go:308"]
+    B --> C["mcp.Transport (seam)<br/>mcp/transport.go:52<br/>Connect(ctx) → Connection"]
+    C --> D["StreamableClientTransport{Endpoint: url}<br/>streamableClientConn → jsonrpc2 engine"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE · DELETE"]
+  W --> E["mcp.NewStreamableHTTPHandler(getServer, opts)<br/>mcp/streamable.go:232 → ServeHTTP"]
+  subgraph SERVER["Go server"]
+    E --> F["StreamableServerTransport<br/>streamable.go:672"]
+    F --> G["server.Connect(ctx, transport) (seam)<br/>server.go:1374 → connect() → t.Connect(ctx)"]
+    G --> H["jsonrpc2 → MCP handlers"]
+  end
+  ALT["Alternative carrier:<br/>implement mcp.Transport<br/>InMemoryTransport · StdioTransport<br/>custom-transport example"]
+  C -.-> ALT
+  ALT -.-> G
+```
+
+- **Seam:** `mcp.Transport` interface (`mcp/transport.go:52`): single method `Connect(ctx) (Connection, error)`; the returned `Connection` (transport.go:73-94) carries `Read`/`Write`/`Close`/`SessionID`. Injection is direct on both sides: `Client.Connect(ctx, t Transport)` (client.go:308) and `Server.Connect(ctx, t Transport)` (server.go:1374), both through the shared `connect()` helper (transport.go:185-209) that wraps the connection in the `jsonrpc2` engine. Shipped precedents: `NewInMemoryTransports()` (net.Pipe-backed), `StdioTransport`, `IOTransport`, and a full custom-transport example (examples/server/custom-transport/main.go).
+
+---
+
+## PHP
+
+- **Version:** php-sdk main @ c882401 (2026-08-22). Dual-era: `StreamableHttpTransport` serves handshake-era sessions and modern stateless envelopes off one endpoint, classified per request; `StatelessHttpTransport` is a modern-only POST-only PSR-15 handler that is **not** a `TransportInterface`.
+- **Wire:** single endpoint. POST JSON-RPC (single or batch) with `Content-Type: application/json`, `Accept: application/json, text/event-stream`, `Mcp-Session-Id` (handshake era), per-message `MCP-Protocol-Version`/`Mcp-Method`/`Mcp-Name`/`Mcp-Param-*`. Response: 200 JSON (single or `[msg,msg]`), 202 empty, or 200 SSE (`event: message` / `data: <JSON>` frames). DELETE + `Mcp-Session-Id` on close. Modern: POST-only, version/capabilities in `params._meta`, `subscriptions/listen` SSE.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["PHP client"]
+    A["App: $client->connect($transport)<br/>src/Client.php:84"] --> B["Client TransportInterface (seam)<br/>src/Client/Transport/TransportInterface.php"]
+    B --> C["Protocol::connect → onMessage/onInitialize<br/>src/Client/Protocol.php:120"]
+    C --> D["HttpTransport<br/>PSR-18 POST + SSE parse"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>DELETE · SSE streaming"]
+  W --> E["StreamableHttpTransport (PSR-15)<br/>src/Server/Transport/StreamableHttpTransport.php"]
+  subgraph SERVER["PHP server"]
+    E --> F["Server TransportInterface (seam)<br/>src/Server/Transport/TransportInterface.php"]
+    F --> G["Server::run($transport)<br/>src/Server.php:34 → listen()"]
+    G --> H["StatelessProtocol / Protocol::processInput<br/>→ handlers"]
+  end
+  ALT["Alternative carrier:<br/>implement role TransportInterface<br/>InMemoryTransport · StdioTransport"]
+  B -.-> ALT
+  ALT -.-> F
+```
+
+- **Seam:** two deliberately asymmetric, same-named interfaces. Client: `Mcp\Client\Transport\TransportInterface` (`connect`, `send(string)`, `runRequest(\Fiber)`, `close`, callbacks) injected at `Client::connect($transport)` (src/Client.php:84). Server: `Mcp\Server\Transport\TransportInterface` (`initialize`, `listen`, `send(string, array $context)`, `close`, providers/finders) injected at `Server::run($transport)` (src/Server.php:34). PR #160 decoupled both `Protocol` classes from owning the transport — processing methods take the transport as a parameter. Shipped precedents: `InMemoryTransport`, `StdioTransport`.
+
+---
+
+## Ruby
+
+- **Version:** ruby-sdk v1.3.0, main @ 2a31e0b (2026-08-24). Dual-era (SEP-2575): legacy handshake sessions and modern stateless exchanges.
+- **Wire:** POST one JSON-RPC 2.0 object (`Content-Type: application/json`, `Accept: application/json, text/event-stream`, `MCP-Session-Id`/`MCP-Protocol-Version` after initialize, `Last-Event-ID` on reconnect). Response: JSON 200/202, or SSE `data: <json>` frames (`SSE_HEADERS`: text/event-stream, no-cache, keep-alive). GET standalone SSE listener; DELETE termination. Modern: POST-only, `_meta` envelope, `server/discover` probe.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Ruby client"]
+    A["App: MCP::Client.new(transport: http)<br/>lib/mcp/client.rb:133"] --> B["duck type send_request(request:) (seam)<br/>docs/_client/transports.md:236"]
+    B --> C["Client#request → transport.send_request<br/>lib/mcp/client.rb:751"]
+    C --> D["MCP::Client::HTTP<br/>Faraday POST + SSE + GET listener"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE · DELETE"]
+  W --> E["StreamableHTTPTransport — Rack app<br/>call(env) → handle_request<br/>streamable_http_transport.rb:258"]
+  subgraph SERVER["Ruby server"]
+    E --> F["MCP::Transport base (seam, coupled)<br/>lib/mcp/transport.rb<br/>send_response/open/close/send_notification"]
+    F --> G["ServerSession#handle_json → @server.handle<br/>lib/mcp/server.rb:278"]
+    G --> H["JsonRpcHandler → tool/prompt/resource handlers"]
+  end
+  ALT["Alternative carrier:<br/>client: any object with send_request(request:)<br/>server: no carrier-neutral seam —<br/>subclass/reimplement the Rack transport"]
+  B -.-> ALT
+  ALT -.-> F
+```
+
+- **Seam:** client = documented duck type: any object implementing `send_request(request:)` (plus optional `send_notification(notification:)`, `connect`, `on_server_request`) injected via the required `transport:` keyword at `MCP::Client.new` (lib/mcp/client.rb:133). Server = `MCP::Transport` base class (`lib/mcp/transport.rb`): subclass must implement `send_response`/`open`/`close`/`send_notification`/`send_request`; the constructor binds itself via `server.transport = self`. **Caveat:** the server side is coupled — `StreamableHTTPTransport` is not just a Transport, it *is* the Rack app (owns `call(env)`, session/stream state, JSON parsing, response building, dispatch). Substituting a server carrier means reimplementing that chain against `MCP::Server#handle`/`ServerSession`; there is no carrier-neutral server transport interface.
+
+---
+
+## Rust (rmcp)
+
+- **Version:** rmcp 3.1.4, main @ 4a738b9 (2026-08-20). Fully migrated to a worker-task model: every transport is a `WorkerTransport<W>` or an adapter over `Sink`/`Stream`/`AsyncRead`/`AsyncWrite`. `ProtocolVersion::LATEST` = 2025-11-25; 2026-07-28 requests are always served statelessly.
+- **Wire:** single URL. POST one JSON-RPC message (`Accept: text/event-stream, application/json`, `Mcp-Session-Id` legacy, `MCP-Protocol-Version` + SEP-2243 headers for ≥ 2026-07-28). Responses: 202 (notifications), 200 JSON, or 200 SSE (one message per event, `id:`/`retry:`, priming events). GET SSE + `Last-Event-ID` (legacy); DELETE (legacy). Caps: client SSE event 16 MiB, server body 4 MiB.
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Rust client (rmcp)"]
+    A["App: StreamableHttpClientTransport::from_uri(url)<br/>streamable_http_client.rs:353"] --> B["client_info.serve(transport)<br/>service.rs:330 (IntoTransport)"]
+    B --> C["Transport trait (seam)<br/>transport.rs:127<br/>send/receive/close"]
+    C --> D["WorkerTransport → reqwest<br/>POST + GET SSE + DELETE"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE (legacy) · DELETE (legacy)"]
+  W --> E["StreamableHttpService<br/>tower.rs:1088 → tower Service"]
+  subgraph SERVER["Rust server (rmcp)"]
+    E --> F["legacy: create_session → per-session Transport<br/>stateless: OneshotTransport<br/>tower.rs:1967"]
+    F --> G["serve_server(service, transport) (seam)<br/>server.rs:419"]
+    G --> H["ServerHandler::handle_request<br/>→ handlers"]
+  end
+  ALT["Alternative carrier:<br/>implement Transport / IntoTransport<br/>SinkStreamTransport · AsyncRwTransport<br/>in-process WorkerTransport"]
+  C -.-> ALT
+  ALT -.-> G
+```
+
+- **Seam:** `Transport` trait (`transport.rs:127`): `send(TxJsonRpcMessage)`, `receive() -> Option<RxJsonRpcMessage>`, `close()` — plus `IntoTransport` (`transport.rs:152`) with blanket impls for `Sink+Stream`, `AsyncRead+AsyncWrite`, `Worker`, and existing `Transport`. Client injection: `client_info.serve(transport)` (service.rs:330, used as `ClientInfo::serve` in examples). Server injection: `serve_server(service, transport)` (server.rs:419) for transport-driven servers; the stateless HTTP path uses `OneshotTransport` per POST (tower.rs:1967). README states any `Transport` implementation can be supplied to `.serve(..)`. Shipped precedents: `SinkStreamTransport`, `AsyncRwTransport`, in-process `WorkerTransport`, `UnixSocketHttpClient`.
+
+---
+
+## Swift
+
+- **Version:** swift-sdk main @ a0ae212 (2026-04-29). No type named `StreamableHTTPClientTransport` — the client is `HTTPClientTransport`; servers are `StatefulHTTPServerTransport` (full streamable spec) and `StatelessHTTPServerTransport` (minimal). Serving is SwiftNIO-based in current main (no Vapor dependency). SSE is Apple-platform-only.
+- **Wire:** single endpoint. POST raw JSON-RPC `Data` with `Accept: application/json, text/event-stream`, `MCP-Protocol-Version`, `MCP-Session-Id` (when held), optional `Authorization`. Responses: 200 JSON (stateless) or SSE (`event: message`, `id: <streamID>_<N>`, `data: <JSON>`, `retry:`); 202 for notifications; DELETE → 200. GET standalone SSE + `Last-Event-ID` resumption (stateful).
+
+```mermaid
+flowchart LR
+  subgraph CLIENT["Swift client"]
+    A["App: HTTPClientTransport(endpoint: url)<br/>HTTPClientTransport.swift:56"] --> B["Client.connect(transport:)<br/>Client.swift:207"]
+    B --> C["Transport protocol (seam)<br/>Base/Transport.swift:6<br/>connect/disconnect/send(Data)/receive"]
+    C --> D["URLSession POST + GET SSE"]
+  end
+  D --> W["HTTP wire: POST JSON-RPC<br/>GET SSE · DELETE"]
+  W --> E["StatefulHTTPServerTransport /<br/>StatelessHTTPServerTransport<br/>Base/Transports/HTTPServer/"]
+  subgraph SERVER["Swift server"]
+    E --> F["Server.start(transport:) (seam)<br/>Server.swift:205"]
+    F --> G["message loop → handleRequest<br/>→ handlers"]
+  end
+  ALT["Alternative carrier:<br/>implement Transport protocol<br/>NetworkTransport · InMemoryTransport<br/>documented MyCustomTransport"]
+  C -.-> ALT
+  ALT -.-> F
+```
+
+- **Seam:** `Transport` protocol (`Base/Transport.swift:6`): `connect()`, `disconnect()`, `send(_ data: Data)`, `receive() -> AsyncThrowingStream<Data, Error>` — deliberately byte-oriented and JSON-RPC-free (the typed adapter lives above it). Injected at `Client.connect(transport:)` (Client.swift:207) and `Server.start(transport:)` (Server.swift:205). Server-side secondary seam: framework-agnostic `HTTPRequest`/`HTTPResponse` with `handleRequest(_:)` — the SwiftNIO `HTTPHandler` is just one framework adapter. Shipped precedents: `NetworkTransport` (Apple Network, TCP/UDP), `InMemoryTransport`, and README's full `MyCustomTransport` actor example.

--- a/proposals/XXXX-pluggable-transports.md
+++ b/proposals/XXXX-pluggable-transports.md
@@ -1,0 +1,1028 @@
+# XXXX: Pluggable Transport Interface for MCP SDKs
+
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2026-08-20
+- **Author(s)**: Kryspin Ziemski (@kziemski), Kurtis Van Gent (@kurtisvg)
+- **Sponsor**: None
+- **Working Group**: Transports Working Group
+- **Target**: Official MCP SDKs
+- **Related**: [SEP-2598](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2598)
+- **Reference specification**: [MCP Transports — 2026-07-28](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2026-07-28/basic/transports/index.mdx)
+
+## Abstract
+
+This proposal standardizes a public, replaceable **transport extension point** across official Model Context Protocol SDKs.
+
+The extension point is intentionally narrower than defining a new MCP transport binding. It standardizes the SDK boundary between MCP protocol processing and the mechanism that carries MCP JSON-RPC messages.
+
+A conforming SDK exposes a public transport abstraction through which a third-party transport implementation can:
+
+1. establish or initialize transport resources;
+2. send one complete MCP JSON-RPC message;
+3. receive one complete MCP JSON-RPC message;
+4. associate optional opaque transport-local context with a message when required by the carrier;
+5. report transport-level errors; and
+6. close or dispose transport resources.
+
+The abstraction MUST preserve MCP JSON-RPC semantics. It does not permit a transport implementation to replace MCP's message model with a native RPC method model.
+
+This proposal does **not** standardize WebSocket, `postMessage`, Cap'n Web, gRPC, QUIC, Unix sockets, or any other carrier as an MCP transport binding. Instead, it creates a consistent SDK extension point through which such carriers can be implemented without modifying the SDK protocol core.
+
+The goal is to make custom JSON-RPC-preserving transports portable as a concept across MCP SDKs while allowing each SDK to retain language-idiomatic APIs.
+
+## Motivation
+
+The MCP transport specification permits custom transports, but the official SDKs do not currently expose a uniformly understood extension boundary for implementing them.
+
+In practice, the SDKs have converged on several related patterns:
+
+- a `Transport` interface carrying typed JSON-RPC messages;
+- a `Transport` plus `Connection` abstraction;
+- read/write streams carrying message envelopes;
+- channels carrying typed JSON-RPC messages;
+- byte- or string-oriented transport protocols with JSON-RPC parsing immediately above them.
+
+This convergence makes a cross-SDK semantic contract practical, but differences in naming, lifecycle, message representation, and transport-specific metadata make third-party transport implementations difficult to design consistently.
+
+Some SDK transport abstractions also expose details specific to Streamable HTTP or historical session semantics, such as:
+
+- session IDs;
+- HTTP headers;
+- request-scoped response streams;
+- resumption tokens;
+- SSE lifecycle callbacks;
+- HTTP request cancellation;
+- HTTP status codes.
+
+These properties are useful to particular transport bindings, but they should not be requirements for every custom transport.
+
+A `postMessage` or `MessagePort` transport, for example, should not need to emulate HTTP headers or an MCP session identifier merely to connect to the MCP protocol engine. Similarly, a WebSocket or Unix-domain-socket implementation should not require changes to request dispatch, JSON-RPC correlation, capability handling, tool invocation, or other MCP protocol logic.
+
+A standardized SDK transport extension point would make the following architecture explicit:
+
+```text
+┌───────────────────────────────────────────────┐
+│             MCP Client / Server               │
+│                                               │
+│ tools, resources, prompts, tasks, elicitation │
+└──────────────────────┬────────────────────────┘
+                       │
+                       ▼
+┌───────────────────────────────────────────────┐
+│             MCP Protocol Engine               │
+│                                               │
+│ JSON-RPC validation and dispatch              │
+│ request / response correlation                │
+│ protocol metadata                             │
+│ MCP lifecycle and capabilities                │
+└──────────────────────┬────────────────────────┘
+                       │
+              MCP JSON-RPC messages
+                       │
+                       ▼
+┌───────────────────────────────────────────────┐
+│        Public SDK Transport Extension Point   │
+│                                               │
+│ start/connect                                 │
+│ send(message, context?)                       │
+│ receive(message, context?)                    │
+│ errors                                        │
+│ close/disconnect                              │
+└──────────────────────┬────────────────────────┘
+                       │
+                       ▼
+      carrier / transport-binding implementation
+```
+
+This is a smaller and more incremental change than SEP-2598. SEP-2598 considered broader transport pluggability, including transports whose native RPC model may not map directly to JSON-RPC. That raises additional questions around request identifiers, notification semantics, cancellation, native RPC errors, and conformance.
+
+This proposal deliberately avoids those questions by keeping MCP JSON-RPC as the semantic boundary.
+
+## Goals
+
+This proposal has the following goals:
+
+1. Define a common semantic transport contract for official MCP SDKs.
+2. Ensure SDK protocol logic can be used with a third-party transport without modifying or forking the protocol implementation.
+3. Preserve MCP JSON-RPC messages and message patterns across the transport boundary.
+4. Allow transport implementations to carry transport-local metadata without leaking carrier-specific concepts into the generic MCP protocol layer.
+5. Remove or isolate HTTP- and session-specific requirements from generic transport abstractions.
+6. Permit SDKs to implement the contract using language-idiomatic interfaces, traits, protocols, channels, callbacks, streams, or async iterators.
+7. Provide common conformance tests that validate the extension point rather than requiring identical APIs.
+8. Make transports such as WebSocket, `postMessage`, `MessagePort`, Unix sockets, named pipes, or RPC tunnels implementable outside the SDK core.
+9. Preserve backward compatibility wherever practical.
+
+## Non-Goals
+
+This proposal does not:
+
+1. add a new standard MCP transport binding;
+2. standardize WebSocket framing;
+3. standardize `postMessage` origin or iframe security rules;
+4. standardize gRPC, Cap'n Web, or another native RPC mapping for MCP;
+5. permit removal of JSON-RPC semantics from MCP;
+6. require all SDKs to expose identically named methods or types;
+7. require all transports to support HTTP concepts;
+8. require all transports to support historical MCP session semantics;
+9. define transport discovery or transport negotiation;
+10. define endpoint URI schemes for custom transports;
+11. require custom transports to be implemented in the official SDK repositories.
+
+## Terminology
+
+### MCP Protocol Engine
+
+The SDK component responsible for MCP protocol behavior, including JSON-RPC dispatch, request/response correlation, MCP method handling, capabilities, protocol metadata, errors, and other protocol semantics.
+
+### SDK Transport Extension Point
+
+The public SDK API through which an implementation supplies a mechanism for sending and receiving MCP JSON-RPC messages.
+
+The concrete API is language-specific.
+
+### Transport Binding
+
+A specification defining how MCP messages are framed and delivered over a particular carrier.
+
+Examples include stdio and Streamable HTTP.
+
+### Carrier
+
+The underlying communication mechanism used by a transport binding or custom transport implementation, such as:
+
+- process stdin/stdout;
+- HTTP;
+- WebSocket;
+- `Window.postMessage`;
+- `MessagePort`;
+- TCP;
+- Unix domain sockets;
+- named pipes;
+- QUIC;
+- a bidirectional RPC stream.
+
+### Transport Context
+
+Opaque, transport-local information associated with a received or outgoing message.
+
+Transport Context exists to support carrier-level routing or lifecycle requirements without adding carrier-specific properties to the generic MCP message model.
+
+Transport Context is not part of the MCP JSON-RPC message and MUST NOT alter MCP protocol semantics.
+
+### Native RPC Binding
+
+An integration that maps MCP operations into the native method, object, capability, or schema model of another RPC system rather than transporting MCP JSON-RPC messages unchanged at the semantic boundary.
+
+A native RPC binding is outside the scope of this proposal.
+
+## Proposed Standard
+
+### 1. Public replacement point
+
+Each Tier 1 official MCP SDK MUST expose a documented public extension point through which an application can supply a custom transport implementation.
+
+Using a custom transport MUST NOT require:
+
+- patching the SDK protocol dispatcher;
+- forking the SDK;
+- reimplementing MCP method dispatch;
+- reimplementing MCP request/response correlation;
+- modifying the JSON-RPC schema;
+- pretending to be Streamable HTTP.
+
+An SDK MAY expose separate client and server transport abstractions where that is more idiomatic.
+
+### 2. Message-oriented semantic boundary
+
+At the semantic boundary between the MCP protocol engine and the transport implementation, each send or receive operation MUST represent exactly one complete MCP JSON-RPC message.
+
+A conforming transport extension point MUST preserve:
+
+- JSON-RPC request semantics;
+- JSON-RPC response semantics;
+- JSON-RPC notification semantics;
+- JSON-RPC errors;
+- MCP method names;
+- MCP parameters;
+- MCP result values;
+- MCP protocol metadata;
+- request identifiers where present in the applicable protocol version.
+
+An SDK SHOULD expose its canonical typed JSON-RPC message type at this boundary when such a type exists.
+
+An SDK MAY expose an encoded UTF-8 JSON value, byte buffer, string, stream item, or language-native JSON value instead when that representation is idiomatic, provided that:
+
+1. a single transport send/receive item corresponds to a single complete MCP JSON-RPC message; and
+2. the SDK provides the canonical adapter between that representation and its MCP protocol engine.
+
+The purpose of this requirement is semantic consistency, not identical language APIs.
+
+### 3. Lifecycle
+
+The extension point MUST provide semantic equivalents for:
+
+- **start/connect/open** — acquire transport resources and begin processing;
+- **send/write** — submit an MCP JSON-RPC message for delivery;
+- **receive/read/on-message** — deliver an MCP JSON-RPC message to the protocol engine;
+- **close/disconnect/dispose** — release transport resources and stop processing.
+
+The exact method names and control-flow style are implementation-defined.
+
+For example, all of the following may conform:
+
+```text
+start() + send() + onMessage + close()
+```
+
+```text
+Connect() -> Connection
+Connection.Read()
+Connection.Write()
+Connection.Close()
+```
+
+```text
+async context manager -> (read_stream, write_stream)
+```
+
+```text
+AsyncSequence + send() + disconnect()
+```
+
+```text
+ChannelReader + SendMessageAsync()
+```
+
+### 4. Transport errors
+
+A transport implementation MUST have a mechanism to report transport-level failures separately from valid MCP JSON-RPC error responses.
+
+Examples of transport-level failures include:
+
+- connection failure;
+- malformed carrier framing;
+- unexpected EOF;
+- WebSocket closure;
+- failed process startup;
+- network timeout;
+- underlying stream failure.
+
+A transport failure MUST NOT be converted into an MCP JSON-RPC error unless an MCP request was successfully received and the MCP protocol implementation determines that a JSON-RPC response is appropriate.
+
+SDKs MAY use exceptions, error return values, failed futures/promises, stream errors, channel completion errors, or callbacks.
+
+### 5. Opaque Transport Context
+
+An SDK SHOULD support optional opaque Transport Context when a transport binding requires carrier-level association between an incoming message and a later outgoing message.
+
+Conceptually:
+
+```text
+TransportMessage {
+    message: MCP JSON-RPC message
+    context?: opaque transport-local value
+}
+```
+
+The context is intentionally not standardized as a serialized data structure.
+
+The MCP protocol engine MUST treat Transport Context as opaque.
+
+The protocol engine MUST NOT inspect transport-specific fields such as:
+
+- HTTP headers;
+- HTTP request objects;
+- HTTP response streams;
+- WebSocket handles;
+- SSE event IDs;
+- QUIC stream IDs;
+- `MessagePort` objects;
+- RPC call handles.
+
+An SDK MAY implement Transport Context using:
+
+- a generic type;
+- an opaque object;
+- a language-native context value;
+- existing message metadata;
+- an envelope type;
+- an implementation-private association.
+
+An SDK MAY omit explicit Transport Context from its public API if its execution model preserves the required request-to-carrier association internally.
+
+### 6. Transport-specific extensions
+
+Transport-specific functionality SHOULD be represented through optional extension interfaces, capabilities, adapters, or implementation-specific types rather than mandatory members of the generic transport contract.
+
+For example:
+
+```text
+Generic Transport
+    ├── HTTPTransportExtensions
+    ├── ResumableTransportExtensions
+    ├── ProcessTransportExtensions
+    └── Custom transport-specific API
+```
+
+Generic transport implementations MUST NOT be required to implement:
+
+- `SessionId`;
+- HTTP request headers;
+- HTTP response headers;
+- HTTP status codes;
+- SSE event IDs;
+- resumption tokens;
+- per-request HTTP streams;
+- process identifiers;
+- stderr access.
+
+Existing SDK properties MAY remain temporarily for backward compatibility but SHOULD be deprecated or moved behind an optional transport-specific extension during the next compatible API evolution.
+
+### 7. Protocol semantics remain above transport
+
+The following responsibilities belong to the MCP protocol engine and MUST NOT need to be reimplemented by a custom JSON-RPC-preserving transport:
+
+- JSON-RPC request/response correlation;
+- MCP method dispatch;
+- tool invocation semantics;
+- resource semantics;
+- prompt semantics;
+- task semantics;
+- capability interpretation;
+- protocol-version behavior;
+- MCP-level errors;
+- request metadata semantics;
+- JSON-RPC notification handling.
+
+A transport MAY validate framing or decode JSON into the SDK's canonical JSON-RPC type.
+
+A transport MUST NOT reinterpret an MCP method such as `tools/call` as a different semantic operation visible to the MCP protocol engine.
+
+### 8. No requirement for identical SDK APIs
+
+Conformance is behavioral.
+
+This proposal does not require a literal interface with the following source representation:
+
+```text
+interface Transport {
+    connect()
+    send(message, context?)
+    receive() -> (message, context?)
+    close()
+}
+```
+
+That pseudo-interface defines the semantic contract only.
+
+SDKs SHOULD preserve established language conventions and existing stable APIs.
+
+### 9. Message-oriented boundary and exchange scoping
+
+Request-scoped carriers (Streamable HTTP, unary-plus-streaming RPC, serverless
+invocations) naturally associate each request with its own response stream,
+while connection-oriented carriers (stdio, WebSocket, MessagePort) multiplex
+many independent exchanges over one connection. These differ in how responses
+are delivered, not in what crosses the boundary.
+
+This proposal keeps the semantic unit at the boundary as one complete MCP
+JSON-RPC message rather than an exchange object, for two reasons:
+
+1. Request/response correlation is an MCP protocol-engine responsibility (see
+   §7). The JSON-RPC request id, which the applicable protocol version
+   requires, lets the protocol engine associate responses; the transport must
+   not re-implement correlation as a separate boundary parameter.
+2. A message-oriented boundary is the common denominator across both carrier
+   kinds: a connection-oriented transport carries many messages, and a
+   request-scoped transport carries the messages of one exchange.
+
+Request-scoped association is preserved at the boundary in two ways:
+
+- the JSON-RPC request id, carried inside the message, for protocol-level
+  correlation; and
+- opaque Transport Context (see §5) where the carrier must route a response
+  back through the correct ingress operation (an HTTP POST, an RPC call, a
+  `MessagePort`), without exposing carrier-specific fields to the protocol
+  engine.
+
+An SDK MAY offer a higher-level exchange API (for example
+`exchange(request) -> AsyncIterable<Response | Notification>`) as an idiomatic
+convenience, provided the underlying boundary still satisfies the
+message-oriented contract in §2 and §3.
+
+## Transport Versus Native RPC Binding
+
+This proposal distinguishes a JSON-RPC-preserving transport from a native RPC binding.
+
+### In scope
+
+The following is a transport:
+
+```text
+MCP protocol
+    │
+    ▼
+MCP JSON-RPC message
+    │
+    ▼
+GrpcTunnelTransport
+    │
+    ▼
+bidirectional gRPC stream carrying the MCP message
+```
+
+The gRPC layer may provide:
+
+- HTTP/2;
+- TLS/mTLS;
+- load balancing;
+- observability;
+- service discovery;
+- multiplexing.
+
+MCP still owns the RPC semantics.
+
+Likewise:
+
+```text
+MCP JSON-RPC
+    │
+    ▼
+CapnWebTransport
+    │
+    ▼
+Cap'n Web invocation carrying an MCP message
+```
+
+is in scope if the Cap'n Web layer is only carrying MCP messages.
+
+### Out of scope
+
+The following is a native RPC binding:
+
+```text
+tools/call
+    │
+    ▼
+nativeRemote.tools.call(...)
+```
+
+or:
+
+```text
+resources/read
+    │
+    ▼
+GrpcMcp.ResourcesRead(...)
+```
+
+where the underlying RPC framework replaces JSON-RPC method, request, response, notification, error, or correlation semantics.
+
+A future proposal MAY define a standard abstraction for native RPC bindings. That proposal would need to address semantic mapping and conformance independently.
+
+## Illustrative Transport Implementations
+
+The following examples are non-normative.
+
+### `PostMessageTransport`
+
+A browser or worker transport could use `postMessage` or `MessagePort`. MCP
+messages are UTF-8 JSON-RPC, so a conforming transport sends and receives the
+JSON document as a text value rather than a raw structured-clone object, and
+enforces an origin/source policy:
+
+```ts
+class PostMessageTransport implements Transport {
+  constructor(options: {
+    port: MessagePort;
+    expectedSource?: MessagePort | Window | null;
+  }) {
+    this.port = options.port;
+    this.expectedSource = options.expectedSource;
+  }
+
+  async start(): Promise<void> {
+    this.port.addEventListener("message", this.handleMessage);
+    this.port.start?.();
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    // Send the complete MCP JSON-RPC message as a UTF-8 JSON text document.
+    this.port.postMessage(JSON.stringify(message));
+  }
+
+  async close(): Promise<void> {
+    this.port.removeEventListener("message", this.handleMessage);
+    this.port.close?.();
+  }
+
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  private handleMessage = (event: MessageEvent) => {
+    if (this.expectedSource && event.source !== this.expectedSource) {
+      return; // drop messages from unvalidated senders
+    }
+    if (typeof event.data !== "string") {
+      return; // require the JSON text representation
+    }
+    let message: JSONRPCMessage;
+    try {
+      message = JSON.parse(event.data);
+    } catch {
+      return; // malformed carrier input; ignore or surface a controlled error
+    }
+    this.onmessage?.(message);
+  };
+}
+```
+
+The example is illustrative. A `Window.postMessage` variant must additionally
+supply a `targetOrigin` and validate the sender origin; a dedicated
+`MessagePort` already scopes the channel, so origin policy reduces to
+validating the expected peer. Security policy, allowed origins, channel
+establishment, and browser framing rules belong to the `postMessage` transport
+binding or application, not this proposal.
+
+### `WebSocketTransport`
+
+A WebSocket implementation can carry one complete serialized MCP JSON-RPC message per WebSocket message:
+
+```text
+JSONRPCMessage
+      │
+      ▼
+ JSON encode
+      │
+      ▼
+WebSocket message
+      │
+      ▼
+ JSON decode
+      │
+      ▼
+JSONRPCMessage
+```
+
+The WebSocket binding would separately define subprotocol negotiation, binary versus text frames, connection establishment, authentication, cancellation, and close behavior.
+
+### RPC tunnel
+
+A generic RPC framework may transport an MCP message as a payload:
+
+```proto
+service McpTunnel {
+  rpc Connect(stream McpEnvelope) returns (stream McpEnvelope);
+}
+
+message McpEnvelope {
+  bytes json_rpc = 1;
+}
+```
+
+This remains an MCP transport because JSON-RPC remains the semantic protocol visible to the MCP engine.
+
+## SDK Alignment
+
+The following table describes the current architectural direction and the smallest expected alignment work. Exact APIs remain owned by each SDK.
+
+| SDK | Current transport boundary | Alignment under this proposal | Expected compatibility |
+| --- | --- | --- | --- |
+| TypeScript | `Transport` carrying typed `JSONRPCMessage` with lifecycle callbacks | Keep the existing abstraction; isolate HTTP/session-specific `TransportSendOptions` and optional members into transport-specific extensions or opaque context | High; expected to be additive/deprecation-based |
+| Python | async transport/context-manager patterns yielding read/write streams of `SessionMessage`; `SessionMessage` already carries JSON-RPC plus metadata | Document the stream-pair/message-envelope contract as the public custom transport extension point; retain Python's stream-oriented API | High; no need to force a callback-style interface |
+| Java | `McpTransport` carrying typed JSON-RPC messages with reactive lifecycle/message handling | Define the existing reactive API as a conforming realization; avoid requiring identical connect/receive method names | High if behavioral rather than signature-based |
+| Kotlin | `Transport` / abstract transport classes carrying typed JSON-RPC messages | Keep the existing abstraction; move carrier-specific options behind extensions/context where necessary | High |
+| C# | `ITransport` / client transport abstractions using typed JSON-RPC and channels/readers | Treat channel-based receive and async send as conforming; isolate `SessionId` or HTTP-specific behavior | High |
+| Go | `Transport.Connect()` returning a `Connection` with typed JSON-RPC `Read`, `Write`, and `Close` | Use as a reference semantic model; move historical `SessionID()` out of the minimal generic connection contract when compatibility permits | Very high |
+| PHP | `TransportInterface` with lifecycle callbacks, strings, and context arrays | Keep public interface; standardize that each send/receive item is one complete MCP JSON-RPC message and define context as transport-local; optionally add typed JSON-RPC adapters | Moderate-high |
+| Ruby | transport base abstractions around JSON/Hash messages and transport-owned processing | Formalize/document a stable custom transport contract and keep idiomatic callbacks/queues/loops; introduce a message envelope only if needed | Moderate-high |
+| Rust | `Transport` trait with typed transmit/receive JSON-RPC message types and transport error type | Treat the existing trait as conforming; do not add context or connect methods unless required by a concrete binding | Very high |
+| Swift | `Transport` protocol using `Data`, async receive streams, connect/disconnect | Preserve the byte-oriented protocol; provide/document the canonical one-message JSON-RPC adapter at the protocol boundary; optionally add a typed higher-level transport protocol later | High |
+
+## SDK-Specific Guidance
+
+### TypeScript
+
+The existing TypeScript `Transport` interface is close to the intended reference abstraction.
+
+The SDK SHOULD:
+
+1. preserve `start`, `send`, `onmessage`, `onerror`, `onclose`, and `close`;
+2. preserve `JSONRPCMessage` as the generic message boundary;
+3. avoid adding additional Streamable HTTP concerns to the generic interface;
+4. migrate HTTP-specific send options to an HTTP extension or opaque context;
+5. keep compatibility aliases or deprecated optional fields until the next appropriate breaking release.
+
+A third-party custom transport should only need the shared protocol package and transport interface, not the Streamable HTTP implementation.
+
+### Python
+
+Python SHOULD retain its stream-oriented architecture.
+
+A conforming Python extension point may remain equivalent to:
+
+```python
+async with transport(...) as (read_stream, write_stream):
+    ...
+```
+
+where stream items are `SessionMessage` values containing an MCP JSON-RPC message and optional metadata.
+
+`SessionMessage.metadata` is a natural realization of Transport Context, provided transport-specific metadata remains opaque to generic protocol code.
+
+The proposal SHOULD NOT require Python to replace AnyIO streams with a callback-oriented `Transport` interface.
+
+### Java
+
+Java SHOULD preserve its reactive programming model.
+
+A reactive stream, sink, handler, `Mono`, or `Flux` based receive/send lifecycle satisfies this proposal when:
+
+- the extension point is public;
+- one logical item corresponds to one MCP JSON-RPC message;
+- a custom transport can be installed without changing protocol dispatch.
+
+If adding new abstract methods to `McpTransport` would break third-party implementations, the SDK SHOULD prefer default methods, sub-interfaces, adapters, or documentation of the existing semantic equivalence.
+
+### Kotlin
+
+Kotlin's existing `Transport` model already closely matches the desired contract.
+
+Kotlin SHOULD keep typed JSON-RPC messages at the transport boundary and SHOULD isolate carrier-specific send options from the generic transport contract.
+
+### C#
+
+The C# SDK MAY continue to represent incoming transport messages through a `ChannelReader<JsonRpcMessage>` or equivalent asynchronous stream and outgoing messages through `SendMessageAsync`.
+
+A literal `ReceiveAsync()` method is not required.
+
+Session or HTTP properties SHOULD be optional extensions rather than requirements for arbitrary `ITransport` implementations.
+
+### Go
+
+Go's `Transport` and `Connection` split is an example of an idiomatic realization:
+
+```go
+type Transport interface {
+    Connect(context.Context) (Connection, error)
+}
+
+type Connection interface {
+    Read(context.Context) (jsonrpc.Message, error)
+    Write(context.Context, jsonrpc.Message) error
+    Close() error
+}
+```
+
+This proposal does not require that exact shape in other SDKs.
+
+Historical or binding-specific properties such as `SessionID()` SHOULD NOT be part of the minimum transport contract once compatibility permits their removal.
+
+### PHP
+
+PHP MAY continue to expose encoded JSON strings and context arrays.
+
+The SDK SHOULD document that:
+
+1. a `send` call contains one complete MCP JSON-RPC message;
+2. each receive callback represents one complete MCP JSON-RPC message;
+3. the context parameter is transport-local and opaque to generic MCP protocol code.
+
+A typed message adapter MAY be added without removing the existing string API.
+
+HTTP status codes, Fibers, session identifiers, and HTTP lifecycle concepts SHOULD remain implementation-specific.
+
+### Ruby
+
+Ruby SHOULD define a stable public contract for custom transports around its existing transport base class or module.
+
+The contract MAY remain Hash/JSON-oriented rather than introducing a rigid typed message hierarchy.
+
+The important requirement is that custom transports can deliver and receive complete MCP JSON-RPC messages without owning MCP protocol dispatch.
+
+### Rust
+
+Rust's typed `Transport` trait is already strongly aligned with the proposal.
+
+The SDK SHOULD avoid changing the trait solely to add a literal `connect()` method if transport construction or conversion already represents connection establishment.
+
+Similarly, opaque context SHOULD NOT be added to the base trait unless a concrete transport requires it. A wrapper/envelope trait or transport-specific extension can be used when needed.
+
+### Swift
+
+Swift MAY retain `Data` as the low-level transport representation.
+
+To make the replacement point unambiguous, the SDK SHOULD document or expose the canonical adapter that converts between exactly one `Data` value and exactly one MCP JSON-RPC message before protocol dispatch.
+
+A future additive `JSONRPCTransport` protocol MAY provide a typed layer without breaking existing implementations.
+
+## Conformance
+
+Conformance MUST validate behavior, not identical source APIs.
+
+A language-agnostic transport extension-point conformance suite SHOULD be defined.
+
+Each Tier 1 SDK SHOULD provide an **in-memory conformance transport** implementing its public extension point.
+
+The test harness SHOULD verify at least the following.
+
+### Required tests
+
+1. **Third-party replacement**
+   - The test transport is supplied through public API only.
+   - No protocol dispatcher code is modified.
+
+2. **Request delivery**
+   - A valid MCP JSON-RPC request crosses the transport boundary unchanged semantically.
+
+3. **Response delivery**
+   - The corresponding JSON-RPC response crosses the transport boundary unchanged semantically.
+
+4. **Notification delivery**
+   - A valid notification can cross the boundary without requiring request/response behavior.
+
+5. **Error response**
+   - A valid JSON-RPC error remains a protocol message and is not reported as a transport failure.
+
+6. **Transport failure**
+   - A carrier failure is surfaced through the SDK's transport-error mechanism.
+
+7. **Close**
+   - Closing the transport releases resources and terminates receive processing.
+
+8. **No HTTP dependency**
+   - The conformance transport does not provide HTTP headers, status codes, SSE streams, or an HTTP session identifier.
+
+9. **Protocol reuse**
+   - Existing MCP method dispatch is used unchanged over the custom transport.
+
+10. **Opaque context**
+    - If the SDK exposes Transport Context, the protocol layer preserves the association required to send a carrier-level response while treating the context as opaque.
+
+11. **Concurrent requests**
+    - Multiple overlapping requests resolve to their correct responses even when responses arrive out of order.
+    - A transport MUST NOT lose request/response correlation when a carrier multiplexes independent exchanges — a failure mode observed in a production RPC-carrier transport that kept a single pending-response association ([cloudflare/agents#1540](https://github.com/cloudflare/agents/issues/1540)).
+
+### Recommended tests
+
+The following SHOULD be verified where the SDK and the applicable protocol revision support them:
+
+- **Cancellation** — the carrier's cancellation mechanism realizes MCP cancellation rules without stranding underlying request resources.
+- **Malformed input** — non-MCP data may be ignored; malformed values claiming to be JSON-RPC produce a controlled error rather than crashing the transport.
+- **Backpressure** — a slow receiver cannot silently overwrite earlier messages; queue behavior is documented.
+- **Extension fields** — unknown `_meta` and extension fields survive the carrier unchanged, avoiding transports that reserialize only known schema fields.
+- **Protocol-version behavior** — unsupported protocol versions fail predictably and supported versions are forwarded correctly.
+- **Long-lived response streams** — a long-lived request/response operation such as `subscriptions/listen` completes over the custom transport where the applicable protocol revision supports it.
+
+### Optional interoperability fixture
+
+The working group MAY define a shared, language-agnostic fixture containing canonical JSON-RPC request, response, notification, and error examples, plus the concurrent-request and long-lived-stream scenarios above.
+
+The fixture SHOULD test semantic equivalence without requiring a specific programming language representation, so each SDK can drive it through its own idiomatic harness rather than maintaining a separate per-SDK conformance suite.
+
+## Reference Implementation
+
+The reference work for this proposal SHOULD include two layers.
+
+### 1. In-memory conformance transport
+
+Every SDK should have or add a minimal in-memory implementation exercising the public extension point.
+
+This validates the abstraction itself without introducing network behavior.
+
+### 2. Non-core custom transport example
+
+At least one SDK SHOULD provide a proof-of-concept custom transport outside its Streamable HTTP and stdio implementations.
+
+A TypeScript `PostMessageTransport` or `MessagePortTransport` is a strong candidate because it demonstrates a carrier with none of the following:
+
+- HTTP methods;
+- HTTP headers;
+- SSE;
+- MCP HTTP sessions;
+- process stdin/stdout.
+
+A WebSocket transport is another suitable proof of concept.
+
+The proof of concept does not become a standard MCP transport merely by implementing the SDK extension point.
+
+## Backward Compatibility
+
+This proposal is intended to be backward compatible.
+
+Existing stdio and Streamable HTTP behavior is unchanged.
+
+Existing SDK transport APIs SHOULD remain source-compatible where practical.
+
+Where a generic transport interface currently exposes carrier-specific members, SDKs SHOULD use one or more of:
+
+1. optional extension interfaces;
+2. adapters;
+3. default implementations;
+4. deprecated compatibility properties;
+5. a new additive transport abstraction;
+6. removal only during an otherwise appropriate major release.
+
+This proposal does not require an SDK to remove a stable API solely to achieve immediate conformance.
+
+An existing transport can conform through an adapter.
+
+## Security Considerations
+
+Making transports easier to replace creates additional opportunities for unsafe transport implementations. This proposal does not weaken the security requirements of any standard MCP transport.
+
+Custom transport authors are responsible for documenting and enforcing the security model of their carrier.
+
+Examples include:
+
+### Browser messaging
+
+`postMessage` transports should consider:
+
+- target-origin restrictions;
+- source-window validation;
+- `MessagePort` ownership;
+- iframe sandboxing;
+- message validation;
+- confused-deputy risks.
+
+### WebSocket
+
+WebSocket transports should consider:
+
+- origin validation where applicable;
+- authentication;
+- TLS;
+- cross-site WebSocket hijacking;
+- proxy behavior;
+- frame and message limits.
+
+### Local IPC
+
+Unix sockets and named pipes should consider:
+
+- filesystem or pipe permissions;
+- local privilege boundaries;
+- peer identity;
+- socket path substitution.
+
+### RPC tunnels
+
+gRPC, Cap'n Web, or other RPC tunnels should consider:
+
+- authentication;
+- authorization;
+- endpoint identity;
+- metadata propagation;
+- capability leakage;
+- intermediary behavior.
+
+Transport Context MUST be treated as untrusted unless the transport's security model establishes otherwise.
+
+Transport Context MUST NOT implicitly grant MCP authorization merely because it was supplied by the carrier.
+
+## Alternatives Considered
+
+### 1. Standardize WebSocket directly
+
+Rejected as the first step.
+
+WebSocket is one useful carrier but does not solve the broader SDK extension-point inconsistency.
+
+A clean SDK transport interface makes WebSocket implementable without requiring it to become a core MCP binding.
+
+### 2. Adopt the full scope of SEP-2598
+
+Not proposed here.
+
+SEP-2598 explored broader pluggability, including transport or RPC systems whose semantics may differ from JSON-RPC.
+
+That broader scope raises questions that are unnecessary for JSON-RPC-preserving carriers.
+
+This proposal intentionally standardizes the smaller common denominator first.
+
+### 3. Require identical `Transport` interfaces in every language
+
+Rejected.
+
+The SDKs use different concurrency and resource-management models.
+
+Forcing Java reactive APIs, Python streams, Rust traits, Go connections, C# channels, and Swift async sequences into one literal signature would create unnecessary breaking changes and non-idiomatic APIs.
+
+Behavioral conformance provides the useful interoperability property.
+
+### 4. Keep transport APIs entirely SDK-specific
+
+Rejected.
+
+Although custom transports are protocol-valid today, the absence of a common public extension contract makes third-party transports harder to implement, document, test, and port across SDKs.
+
+### 5. Move all transport metadata into JSON-RPC `_meta`
+
+Rejected.
+
+Carrier-level routing handles, streams, ports, request objects, and connection objects are not protocol metadata and often cannot or should not be serialized.
+
+Transport Context remains local and opaque.
+
+### 6. Define a native gRPC or Cap'n Web abstraction now
+
+Deferred.
+
+Native RPC mappings are a separate protocol-binding problem.
+
+They should not block standardization of the JSON-RPC-preserving extension point already approximated by most SDKs.
+
+## Implementation Plan
+
+### Phase 1: semantic contract
+
+- [ ] Agree on the behavioral requirements in this proposal.
+- [ ] Inventory the public transport replacement point in every Tier 1 SDK.
+- [ ] Identify carrier-specific leakage in each generic transport abstraction.
+- [ ] Agree on the role of opaque Transport Context.
+
+### Phase 2: per-SDK alignment
+
+- [ ] TypeScript: isolate HTTP-specific generic transport options where practical.
+- [ ] Python: document/formalize the stream-pair `SessionMessage` extension contract.
+- [ ] Java: document the reactive transport API as a conforming realization and add adapters only where required.
+- [ ] Kotlin: document existing `Transport` conformance and isolate binding-specific options.
+- [ ] C#: document channel/async semantics and isolate session-specific members.
+- [ ] Go: document `Transport`/`Connection` as a conforming realization and plan removal or isolation of session-specific members.
+- [ ] PHP: document one-message send/receive semantics and opaque context behavior; add typed adapter if useful.
+- [ ] Ruby: formalize the public custom transport replacement contract.
+- [ ] Rust: document existing trait conformance; avoid unnecessary signature changes.
+- [ ] Swift: document the JSON-RPC adapter boundary over the existing `Data` transport protocol.
+
+### Phase 3: conformance
+
+- [ ] Add an in-memory custom-transport conformance implementation to each Tier 1 SDK.
+- [ ] Add shared semantic test fixtures.
+- [ ] Verify request, response, notification, close, and transport-failure behavior.
+- [ ] Verify the custom implementation does not require HTTP/session members.
+
+### Phase 4: proof of concept
+
+- [ ] Implement `PostMessageTransport` or `MessagePortTransport` in TypeScript as a non-core example.
+- [ ] Optionally implement a WebSocket transport using the same public extension point.
+- [ ] Document how an RPC tunnel can carry MCP JSON-RPC without becoming a native RPC binding.
+
+## Open Questions
+
+1. Should the generic concept be named `Transport`, `MessageTransport`, or `JSONRPCTransport` in specification prose?
+2. Should Transport Context be a SHOULD-level capability or merely an allowed implementation technique?
+3. Should a common transport-capabilities vocabulary be introduced later for features such as resumability or per-request cancellation?
+4. Should the conformance fixture cover backward-compatible protocol revisions that include historical session behavior?
+5. Should reference custom transports live in SDK repositories, a transport-examples repository, or independent packages?
+6. Should a future proposal define package naming or discovery conventions for third-party transports?
+7. Should native RPC bindings receive a distinct governance term such as `Protocol Binding` or `RPC Binding` to prevent confusion with message-preserving transports?
+
+## Rationale
+
+The official SDKs are already close enough to a common transport abstraction that standardization can be incremental rather than disruptive.
+
+The useful cross-language invariant is not a particular interface signature. It is the existence of a stable public boundary where:
+
+```text
+MCP protocol logic
+        │
+        ▼
+one complete MCP JSON-RPC message
+        │
+        ▼
+replaceable transport implementation
+```
+
+By standardizing this boundary first, MCP gains a practical foundation for transport experimentation without prematurely standardizing every carrier or solving native-RPC semantic mapping.
+
+This enables third-party transports such as:
+
+- `PostMessageTransport`;
+- `MessagePortTransport`;
+- `WebSocketTransport`;
+- Unix socket transport;
+- named-pipe transport;
+- QUIC-based transport;
+- gRPC JSON-RPC tunnel;
+- Cap'n Web JSON-RPC tunnel.
+
+The same extension point also creates a clean place to evaluate future transport bindings through implementations before promoting any one carrier into the MCP core specification.
+
+## References
+
+- [MCP Transports Working Group proposals](https://github.com/modelcontextprotocol/transports-wg/tree/main/proposals)
+- [MCP Transport specification — 2026-07-28](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2026-07-28/basic/transports/index.mdx)
+- [SEP-2598: Pluggable transports](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2598)
+- [SEP-1352: Add gRPC as a transport](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1352)
+- [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [Python SDK](https://github.com/modelcontextprotocol/python-sdk)
+- [Java SDK](https://github.com/modelcontextprotocol/java-sdk)
+- [Kotlin SDK](https://github.com/modelcontextprotocol/kotlin-sdk)
+- [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk)
+- [Go SDK](https://github.com/modelcontextprotocol/go-sdk)
+- [PHP SDK](https://github.com/modelcontextprotocol/php-sdk)
+- [Ruby SDK](https://github.com/modelcontextprotocol/ruby-sdk)
+- [Rust SDK](https://github.com/modelcontextprotocol/rust-sdk)
+- [Swift SDK](https://github.com/modelcontextprotocol/swift-sdk)
+- [Cap'n Web](https://github.com/cloudflare/capnweb)


### PR DESCRIPTION
## Summary

Standardizes a public, replaceable **transport extension point** across official MCP SDKs: the SDK boundary between MCP protocol processing and the mechanism that carries MCP JSON-RPC messages. A conforming SDK exposes a public transport abstraction through which a third-party transport can send and receive complete MCP JSON-RPC messages without forking or modifying protocol dispatch.

## Scope

- **In**: JSON-RPC-preserving custom transports (WebSocket, `postMessage`/`MessagePort`, Unix sockets, named pipes, gRPC/Cap'n Web tunnels carrying opaque MCP JSON-RPC, in-process channels).
- **Out (deliberately)**: native RPC bindings that replace the JSON-RPC method layer (e.g. typed protobuf gRPC services, native Cap'n Web object-capability mappings) — deferred to a separate proposal.
- **Out**: adding any new standard MCP transport binding.

## Why this framing

Narrows the deferred [SEP-2598](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2598): keeps MCP JSON-RPC as the semantic boundary (which the 2026-07-28 spec normatively requires for custom transports), standardizes the SDK extension seam behaviorally rather than by identical API, and centralizes conformance vectors instead of requiring every Tier-1 SDK to maintain its own harness.

## What's here

- `proposals/XXXX-pluggable-transports.md` — the proposal (draft).
- `docs/pluggable/` — supporting research: cross-SDK transport survey and RPC-transport analysis.

## Open for discussion

Draft for WG comment. Highlights for review:

- Message-oriented boundary (one complete JSON-RPC message) vs exchange-oriented API — §9.
- Opaque Transport Context as the only carrier-specific escape hatch — §5.
- Behavioral conformance; concurrency/correlation as the one MUST — §Conformance.
- SDK alignment table and per-SDK guidance — §SDK Alignment.

Ready for feedback.